### PR TITLE
refactor(linux): use AppendData() library.Log func

### DIFF
--- a/executor/flags.go
+++ b/executor/flags.go
@@ -19,7 +19,7 @@ var Flags = []cli.Flag{
 	&cli.StringFlag{
 		EnvVars: []string{"EXECUTOR_LOG_LEVEL", "VELA_LOG_LEVEL", "LOG_LEVEL"},
 		Name:    "executor.log.level",
-		Usage:   "set log level - options: (trace|debug|info|warn|error|fatal|panic)",
+		Usage:   "sets the log level for the executor",
 		Value:   "info",
 	},
 
@@ -28,7 +28,7 @@ var Flags = []cli.Flag{
 	&cli.StringFlag{
 		EnvVars: []string{"VELA_EXECUTOR_DRIVER", "EXECUTOR_DRIVER"},
 		Name:    "executor.driver",
-		Usage:   "executor driver",
+		Usage:   "sets the driver to be used for the executor",
 		Value:   constants.DriverLinux,
 	},
 }

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -183,7 +183,9 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	}
 
 	// update the init log with progress
-	l.SetData(append(l.GetData(), []byte("$ Inspecting runtime network...\n")...))
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData([]byte("$ Inspecting runtime network...\n"))
 
 	// inspect the runtime network for the pipeline
 	network, err := c.Runtime.InspectNetwork(ctx, p)
@@ -193,7 +195,9 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	}
 
 	// update the init log with network info
-	l.SetData(append(l.GetData(), network...))
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData(network)
 
 	c.logger.Info("creating volume")
 	// create the runtime volume for the pipeline
@@ -204,7 +208,9 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	}
 
 	// update the init log with progress
-	l.SetData(append(l.GetData(), []byte("$ Inspecting runtime volume...\n")...))
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData([]byte("$ Inspecting runtime volume...\n"))
 
 	// inspect the runtime volume for the pipeline
 	volume, err := c.Runtime.InspectVolume(ctx, p)
@@ -214,10 +220,14 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	}
 
 	// update the init log with volume info
-	l.SetData(append(l.GetData(), volume...))
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData(volume)
 
 	// update the init log with progress
-	l.SetData(append(l.GetData(), []byte("$ Pulling service images...\n")...))
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData([]byte("$ Pulling service images...\n"))
 
 	// create the services for the pipeline
 	for _, s := range p.Services {
@@ -227,12 +237,9 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 		// TODO: remove hardcoded reference
 		// update the init log with progress
-		l.SetData(
-			append(
-				l.GetData(),
-				[]byte(fmt.Sprintf("  $ docker image inspect %s\n", s.Image))...,
-			),
-		)
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData([]byte(fmt.Sprintf("  $ docker image inspect %s\n", s.Image)))
 
 		c.logger.Infof("creating %s service", s.Name)
 		// create the service
@@ -251,13 +258,15 @@ func (c *client) PlanBuild(ctx context.Context) error {
 		}
 
 		// update the init log with service image info
-		l.SetData(append(l.GetData(), image...))
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData(image)
 	}
 
 	// update the init log with progress
-	l.SetData(
-		append(l.GetData(), []byte("$ Pulling stage images...\n")...),
-	)
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData([]byte("$ Pulling stage images...\n"))
 
 	// create the stages for the pipeline
 	for _, s := range p.Stages {
@@ -276,9 +285,9 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	}
 
 	// update the init log with progress
-	l.SetData(
-		append(l.GetData(), []byte("$ Pulling step images...\n")...),
-	)
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData([]byte("$ Pulling step images...\n"))
 
 	// create the steps for the pipeline
 	for _, s := range p.Steps {
@@ -289,12 +298,9 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 		// TODO: make this not hardcoded
 		// update the init log with progress
-		l.SetData(
-			append(
-				l.GetData(),
-				[]byte(fmt.Sprintf("  $ docker image inspect %s\n", s.Image))...,
-			),
-		)
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData([]byte(fmt.Sprintf("  $ docker image inspect %s\n", s.Image)))
 
 		c.logger.Infof("creating %s step", s.Name)
 		// create the step
@@ -313,7 +319,9 @@ func (c *client) PlanBuild(ctx context.Context) error {
 		}
 
 		// update the init log with step image info
-		l.SetData(append(l.GetData(), image...))
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData(image)
 	}
 
 	return nil

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -201,7 +201,9 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 			logger.Trace(logs.String())
 
 			// update the existing log with the new bytes
-			l.SetData(append(l.GetData(), logs.Bytes()...))
+			//
+			// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+			l.AppendData(logs.Bytes())
 
 			logger.Debug("appending logs")
 			// send API call to append the logs for the service
@@ -217,7 +219,9 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 	logger.Trace(logs.String())
 
 	// update the existing log with the last bytes
-	l.SetData(append(l.GetData(), logs.Bytes()...))
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData(logs.Bytes())
 
 	logger.Debug("uploading logs")
 	// send API call to update the logs for the service

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -29,23 +29,17 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 	})
 
 	// update the init log with progress
-	l.SetData(
-		append(
-			l.GetData(),
-			[]byte(fmt.Sprintf("  $ Pulling step images for stage %s...\n", s.Name))...,
-		),
-	)
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData([]byte(fmt.Sprintf("  $ Pulling step images for stage %s...\n", s.Name)))
 
 	// create the steps for the stage
 	for _, step := range s.Steps {
 		// TODO: make this not hardcoded
 		// update the init log with progress
-		l.SetData(
-			append(
-				l.GetData(),
-				[]byte(fmt.Sprintf("    $ docker image inspect %s\n", step.Image))...,
-			),
-		)
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData([]byte(fmt.Sprintf("    $ docker image inspect %s\n", step.Image)))
 
 		logger.Debugf("creating %s step", step.Name)
 		// create the step
@@ -62,7 +56,9 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 		}
 
 		// update the init log with step image info
-		l.SetData(append(l.GetData(), image...))
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData(image)
 	}
 
 	return nil

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -232,7 +232,9 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 			logger.Trace(logs.String())
 
 			// update the existing log with the new bytes
-			l.SetData(append(l.GetData(), logs.Bytes()...))
+			//
+			// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+			l.AppendData(logs.Bytes())
 
 			logger.Debug("appending logs")
 			// send API call to append the logs for the step
@@ -248,7 +250,9 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 	logger.Trace(logs.String())
 
 	// update the existing log with the last bytes
-	l.SetData(append(l.GetData(), logs.Bytes()...))
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData(logs.Bytes())
 
 	logger.Debug("uploading logs")
 	// send API call to update the logs for the step


### PR DESCRIPTION
The codecov checks are failing because this PR reduces the total number of LOC by using the `AppendData()` function. This reduction in LOC causes our % of test coverage to decrease.

I vote we ignore these checks because I'm not really reducing the % of test coverage 👍 