### PR TITLE
fix(secrets): use values from parse functions

### DIFF
--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -265,7 +265,7 @@ func (s *secretSvc) pull(secret *pipeline.Secret) (*library.Secret, error) {
 	switch secret.Type {
 	// handle repo secrets
 	case constants.SecretOrg:
-		err := secret.ValidOrg(s.client.repo.GetOrg())
+		org, key, err := secret.ParseOrg(s.client.repo.GetOrg())
 		if err != nil {
 			return nil, err
 		}
@@ -273,7 +273,7 @@ func (s *secretSvc) pull(secret *pipeline.Secret) (*library.Secret, error) {
 		// send API call to capture the org secret
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#SecretService.Get
-		sec, _, err = s.client.Vela.Secret.Get(secret.Engine, secret.Type, s.client.repo.GetOrg(), "*", secret.Key)
+		sec, _, err = s.client.Vela.Secret.Get(secret.Engine, secret.Type, org, "*", key)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", ErrUnableToRetrieve, err)
 		}
@@ -282,7 +282,7 @@ func (s *secretSvc) pull(secret *pipeline.Secret) (*library.Secret, error) {
 
 	// handle repo secrets
 	case constants.SecretRepo:
-		err := secret.ValidRepo(s.client.repo.GetOrg(), s.client.repo.GetName())
+		org, repo, key, err := secret.ParseRepo(s.client.repo.GetOrg(), s.client.repo.GetName())
 		if err != nil {
 			return nil, err
 		}
@@ -290,7 +290,7 @@ func (s *secretSvc) pull(secret *pipeline.Secret) (*library.Secret, error) {
 		// send API call to capture the repo secret
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#SecretService.Get
-		sec, _, err = s.client.Vela.Secret.Get(secret.Engine, secret.Type, s.client.repo.GetOrg(), s.client.repo.GetName(), secret.Key)
+		sec, _, err = s.client.Vela.Secret.Get(secret.Engine, secret.Type, org, repo, key)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", ErrUnableToRetrieve, err)
 		}
@@ -299,17 +299,15 @@ func (s *secretSvc) pull(secret *pipeline.Secret) (*library.Secret, error) {
 
 	// handle shared secrets
 	case constants.SecretShared:
-		err := secret.ValidShared(s.client.repo.GetOrg())
+		org, team, key, err := secret.ParseShared(s.client.repo.GetOrg())
 		if err != nil {
 			return nil, err
 		}
 
-		team := strings.SplitN(secret.Key, "/", 3)[2]
-
 		// send API call to capture the repo secret
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#SecretService.Get
-		sec, _, err = s.client.Vela.Secret.Get(secret.Engine, secret.Type, s.client.repo.GetOrg(), team, secret.Key)
+		sec, _, err = s.client.Vela.Secret.Get(secret.Engine, secret.Type, org, team, key)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", ErrUnableToRetrieve, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-vela/mock v0.5.0-rc1
 	github.com/go-vela/pkg-runtime v0.5.0-rc1
 	github.com/go-vela/sdk-go v0.5.0-rc1
-	github.com/go-vela/types v0.5.0-rc1.0.20200803122340-285806ff486b
+	github.com/go-vela/types v0.5.0-rc1.0.20200803141719-70581652958d
 	github.com/google/go-cmp v0.5.0
 	github.com/joho/godotenv v1.3.0
 	github.com/onsi/gomega v1.7.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-vela/mock v0.5.0-rc1
 	github.com/go-vela/pkg-runtime v0.5.0-rc1
 	github.com/go-vela/sdk-go v0.5.0-rc1
-	github.com/go-vela/types v0.5.0-rc1
+	github.com/go-vela/types v0.5.0-rc1.0.20200803122340-285806ff486b
 	github.com/google/go-cmp v0.5.0
 	github.com/joho/godotenv v1.3.0
 	github.com/onsi/gomega v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/go-vela/sdk-go v0.5.0-rc1 h1:v8GtUtL08y6Gx81bY2oYskaMSqyEcJNYqvR5xn7t
 github.com/go-vela/sdk-go v0.5.0-rc1/go.mod h1:BKyGRqJZGPEzRQL5aSVGxZLRF2CSI3QcfeW8wUwRlks=
 github.com/go-vela/types v0.5.0-rc1 h1:klHH5hYGb6JU+01gJxCgSe6d6DxxeU3FSpd9VjeLXNM=
 github.com/go-vela/types v0.5.0-rc1/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
+github.com/go-vela/types v0.5.0-rc1.0.20200803122340-285806ff486b h1:2z3cdS7IxuCqSS7cpUKa6OXjQS4P0EVExy6UBliVXWc=
+github.com/go-vela/types v0.5.0-rc1.0.20200803122340-285806ff486b/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/go-vela/sdk-go v0.5.0-rc1 h1:v8GtUtL08y6Gx81bY2oYskaMSqyEcJNYqvR5xn7t
 github.com/go-vela/sdk-go v0.5.0-rc1/go.mod h1:BKyGRqJZGPEzRQL5aSVGxZLRF2CSI3QcfeW8wUwRlks=
 github.com/go-vela/types v0.5.0-rc1 h1:klHH5hYGb6JU+01gJxCgSe6d6DxxeU3FSpd9VjeLXNM=
 github.com/go-vela/types v0.5.0-rc1/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
-github.com/go-vela/types v0.5.0-rc1.0.20200803122340-285806ff486b h1:2z3cdS7IxuCqSS7cpUKa6OXjQS4P0EVExy6UBliVXWc=
-github.com/go-vela/types v0.5.0-rc1.0.20200803122340-285806ff486b/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
+github.com/go-vela/types v0.5.0-rc1.0.20200803141719-70581652958d h1:UslLlfg9F7YcP5QSSRbgT3uq5P5p+GYuVPwZSpvzTjg=
+github.com/go-vela/types v0.5.0-rc1.0.20200803141719-70581652958d/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=


### PR DESCRIPTION
This PR will fix a bug that is stopping us from using the proper key when querying for a secret.

Dependent PR:
https://github.com/go-vela/types/pull/91