### PR TITLE
chore: update go-vela/pkg-runtime for host volumes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-vela/compiler v0.5.0-rc1
 	github.com/go-vela/mock v0.5.0-rc1
-	github.com/go-vela/pkg-runtime v0.5.0-rc1
+	github.com/go-vela/pkg-runtime v0.5.0-rc1.0.20200805191211-be84584fb396
 	github.com/go-vela/sdk-go v0.5.0-rc1
 	github.com/go-vela/types v0.5.0-rc1.0.20200803141719-70581652958d
 	github.com/google/go-cmp v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/go-vela/compiler v0.5.0-rc1 h1:/NZrlAkJmE58VMLQyb4xCTG1Q0frEvWbZT4Er2
 github.com/go-vela/compiler v0.5.0-rc1/go.mod h1:vGA0cNBgAB+/vsUj6y5q7E+TAP6TI1+hFygePqcDuIU=
 github.com/go-vela/mock v0.5.0-rc1 h1:4dG4MDtcRuzBegznvEST+22/2Ij8vSMQw7nEDiwJOjk=
 github.com/go-vela/mock v0.5.0-rc1/go.mod h1:Zq9yCy8g1u5lmC6dBUzj5EFp3cmZx5O/ydHFxWmil1E=
-github.com/go-vela/pkg-runtime v0.5.0-rc1 h1:+xQ18bW/a3X2jkA6VfRBscn0cOKpBlWnBlf5Mqv/kYo=
-github.com/go-vela/pkg-runtime v0.5.0-rc1/go.mod h1:M+4ilay3XMMUgEL86flgGRT08/ul8ojbYn3m0jbowA8=
+github.com/go-vela/pkg-runtime v0.5.0-rc1.0.20200805191211-be84584fb396 h1:OFm0Ez4m8qaYjA2J8IZd77XrQRa2sN8TeKWjjc0nY7g=
+github.com/go-vela/pkg-runtime v0.5.0-rc1.0.20200805191211-be84584fb396/go.mod h1:M+4ilay3XMMUgEL86flgGRT08/ul8ojbYn3m0jbowA8=
 github.com/go-vela/sdk-go v0.5.0-rc1 h1:v8GtUtL08y6Gx81bY2oYskaMSqyEcJNYqvR5xn7tdZA=
 github.com/go-vela/sdk-go v0.5.0-rc1/go.mod h1:BKyGRqJZGPEzRQL5aSVGxZLRF2CSI3QcfeW8wUwRlks=
 github.com/go-vela/types v0.5.0-rc1 h1:klHH5hYGb6JU+01gJxCgSe6d6DxxeU3FSpd9VjeLXNM=


### PR DESCRIPTION
See https://github.com/go-vela/pkg-runtime/pull/52 for more details