### PR TITLE
fix(linux): update build status success at finish

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -454,8 +454,11 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	e := c.err
 
 	defer func() {
-		b.SetStatus(constants.StatusSuccess)
-		c.build = b
+		// NOTE: if the build is already in a failure state we do not
+		// want to update the state to be success
+		if !strings.EqualFold(b.GetStatus(), constants.StatusFailure) {
+			b.SetStatus(constants.StatusSuccess)
+		}
 
 		// NOTE: When an error occurs during a build that does not have to do
 		// with a pipeline we should set build status to "error" not "failed"

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -454,12 +454,12 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	e := c.err
 
 	defer func() {
-		// NOTE: When an error occurs during a build that does not have to do
-		// with a pipeline we should set build status to "error" not "failed"
-		// because it is worker related and not build.
 		b.SetStatus(constants.StatusSuccess)
 		c.build = b
 
+		// NOTE: When an error occurs during a build that does not have to do
+		// with a pipeline we should set build status to "error" not "failed"
+		// because it is worker related and not build.
 		if e != nil {
 			b.SetError(e.Error())
 			b.SetStatus(constants.StatusError)

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -258,9 +258,6 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	r := c.repo
 	e := c.err
 
-	b.SetStatus(constants.StatusSuccess)
-	c.build = b
-
 	defer func() {
 		// NOTE: When an error occurs during a build that does not have to do
 		// with a pipeline we should set build status to "error" not "failed"
@@ -456,13 +453,13 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	r := c.repo
 	e := c.err
 
-	b.SetStatus(constants.StatusSuccess)
-	c.build = b
-
 	defer func() {
 		// NOTE: When an error occurs during a build that does not have to do
 		// with a pipeline we should set build status to "error" not "failed"
 		// because it is worker related and not build.
+		b.SetStatus(constants.StatusSuccess)
+		c.build = b
+
 		if e != nil {
 			b.SetError(e.Error())
 			b.SetStatus(constants.StatusError)
@@ -477,7 +474,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#BuildService.Update
 		_, _, err := c.Vela.Build.Update(r.GetOrg(), r.GetName(), b)
 		if err != nil {
-			c.logger.Errorf("unable to upload errorred state: %v", err)
+			c.logger.Errorf("unable to upload build state: %v", err)
 		}
 	}()
 
@@ -500,6 +497,9 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		}
 	}
 
+	// create a flag to track the build statuses
+	tracker := constants.StatusSuccess
+
 	// execute the steps for the pipeline
 	for _, s := range p.Steps {
 		// TODO: remove hardcoded reference
@@ -512,7 +512,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			Branch: b.GetBranch(),
 			Event:  b.GetEvent(),
 			Repo:   r.GetFullName(),
-			Status: b.GetStatus(),
+			Status: tracker,
 		}
 
 		// when tag event add tag information into ruledata
@@ -529,6 +529,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		if !s.Execute(ruledata) {
 			continue
 		}
+
 		c.logger.Infof("planning %s step", s.Name)
 		// plan the step
 		err := c.PlanStep(ctx, s)
@@ -557,6 +558,8 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			if !s.Ruleset.Continue {
 				// set build status to failure
 				b.SetStatus(constants.StatusFailure)
+
+				tracker = constants.StatusFailure
 			}
 
 			// update the step fields

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/go-vela/sdk-go/vela"
 
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 
 	"github.com/gin-gonic/gin"
@@ -144,11 +143,6 @@ func TestLinux_PlanBuild(t *testing.T) {
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		//TODO: fix this test
-		// { // pipeline empty
-		// 	failure:  true,
-		// 	file:     "testdata/build/empty.yml",
-		// },
 	}
 
 	// run test
@@ -244,10 +238,6 @@ func TestLinux_AssembleBuild(t *testing.T) {
 			failure:  true,
 			pipeline: "testdata/build/stages/img_ignorenotfound.yml",
 		},
-		// { // pipeline empty
-		// 	failure:  true,
-		// 	file:     "testdata/build/empty.yml",
-		// },
 		{ // pipeline with service image tag not found
 			failure:  true,
 			pipeline: "testdata/build/services/img_notfound.yml",
@@ -335,10 +325,6 @@ func TestLinux_ExecBuild(t *testing.T) {
 		failure  bool
 		pipeline string
 	}{
-		// { // pipeline empty
-		// 	failure:  true,
-		// 	file:     "testdata/build/empty.yml",
-		// },
 		{ // basic steps pipeline
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
@@ -379,15 +365,6 @@ func TestLinux_ExecBuild(t *testing.T) {
 			failure:  false,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
-		// TODO: fix this step
-		// { // pipeline with secret image tag not found
-		// 	failure:  true,
-		// 	pipeline: "testdata/build/secrets/img_notfound.yml",
-		// },
-		// { // pipeline with secret name not found
-		// 	failure:  true,
-		// 	pipeline: "testdata/build/secrets/name_notfound.yml",
-		// },
 	}
 
 	// run test
@@ -412,10 +389,6 @@ func TestLinux_ExecBuild(t *testing.T) {
 		if err != nil {
 			t.Errorf("unable to create executor engine: %v", err)
 		}
-
-		build := _engine.build
-		build.SetStatus(constants.StatusSuccess)
-		_engine.build = build
 
 		for _, service := range p.Services {
 			s := &library.Service{

--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -340,6 +340,27 @@ func (s *secretSvc) stream(ctx context.Context, ctn *pipeline.Container) error {
 	// create new buffer for uploading logs
 	logs := new(bytes.Buffer)
 
+	defer func() {
+		// NOTE: Whenever the stream ends we want to ensure
+		// that this function makes the call to update
+		// the step logs
+		logger.Trace(logs.String())
+
+		// update the existing log with the last bytes
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData(logs.Bytes())
+
+		logger.Debug("uploading logs")
+		// send API call to update the logs for the service
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
+		_, _, err = s.client.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+		if err != nil {
+			logger.Error("unable to upload final step state: %w", err)
+		}
+	}()
+
 	logger.Debug("tailing container")
 	// tail the runtime container
 	rc, err := s.client.Runtime.TailContainer(ctx, ctn)
@@ -377,21 +398,6 @@ func (s *secretSvc) stream(ctx context.Context, ctn *pipeline.Container) error {
 			// flush the buffer of logs
 			logs.Reset()
 		}
-	}
-	logger.Trace(logs.String())
-
-	// update the existing log with the last bytes
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData(logs.Bytes())
-
-	logger.Debug("uploading logs")
-	// send API call to update the logs for the service
-	//
-	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
-	_, _, err = s.client.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -518,7 +518,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 		logs      *library.Log
 		container *pipeline.Container
 	}{
-		{
+		{ // container step succeeds
 			failure: false,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
@@ -531,7 +531,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 				Pull:        true,
 			},
 		},
-		{
+		{ // container step fails because of nil logs
 			failure: true,
 			logs:    nil,
 			container: &pipeline.Container{
@@ -544,7 +544,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 				Pull:        true,
 			},
 		},
-		{
+		{ // container step fails because of invalid container id
 			failure: true,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
@@ -554,19 +554,6 @@ func TestLinux_Secret_stream(t *testing.T) {
 				Image:       "target/secret-vault:latest",
 				Name:        "notfound",
 				Number:      2,
-				Pull:        true,
-			},
-		},
-		{
-			failure: true,
-			logs:    new(library.Log),
-			container: &pipeline.Container{
-				ID:          "secret_github_octocat_1_vault",
-				Directory:   "/vela/src/vcs.company.com/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/secret-vault:latest",
-				Name:        "vault",
-				Number:      0,
 				Pull:        true,
 			},
 		},
@@ -596,14 +583,14 @@ func TestLinux_Secret_stream(t *testing.T) {
 
 		if test.failure {
 			if err == nil {
-				t.Errorf("StreamStep should have returned err")
+				t.Errorf("stream should have returned err")
 			}
 
 			continue
 		}
 
 		if err != nil {
-			t.Errorf("StreamStep returned err: %v", err)
+			t.Errorf("stream returned err: %v", err)
 		}
 	}
 }

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -181,6 +181,27 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 	// create new buffer for uploading logs
 	logs := new(bytes.Buffer)
 
+	defer func() {
+		// NOTE: Whenever the stream ends we want to ensure
+		// that this function makes the call to update
+		// the service logs
+		logger.Trace(logs.String())
+
+		// update the existing log with the last bytes
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData(logs.Bytes())
+
+		logger.Debug("uploading logs")
+		// send API call to update the logs for the service
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
+		_, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+		if err != nil {
+			logger.Error("unable to upload final service state: %w", err)
+		}
+	}()
+
 	logger.Debug("tailing container")
 	// tail the runtime container
 	rc, err := c.Runtime.TailContainer(ctx, ctn)
@@ -218,21 +239,6 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 			// flush the buffer of logs
 			logs.Reset()
 		}
-	}
-	logger.Trace(logs.String())
-
-	// update the existing log with the last bytes
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData(logs.Bytes())
-
-	logger.Debug("uploading logs")
-	// send API call to update the logs for the service
-	//
-	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
-	_, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/executor/linux/service_test.go
+++ b/executor/linux/service_test.go
@@ -314,12 +314,12 @@ func TestLinux_StreamService(t *testing.T) {
 		logs      *library.Log
 		container *pipeline.Container
 	}{
-		{
+		{ // container step succeeds
 			failure: false,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "postgres:12-alpine",
 				Name:        "postgres",
@@ -327,25 +327,12 @@ func TestLinux_StreamService(t *testing.T) {
 				Ports:       []string{"5432:5432"},
 			},
 		},
-		{
-			failure: false,
-			logs:    new(library.Log),
-			container: &pipeline.Container{
-				ID:          "service_github_octocat_1_postgres",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "postgres:12-alpine",
-				Name:        "postgres",
-				Number:      1,
-				Ports:       []string{"5432:5432"},
-			},
-		},
-		{
+		{ // container step fails because of nil logs
 			failure: true,
 			logs:    nil,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "postgres:12-alpine",
 				Name:        "postgres",
@@ -353,29 +340,16 @@ func TestLinux_StreamService(t *testing.T) {
 				Ports:       []string{"5432:5432"},
 			},
 		},
-		{
+		{ // container step fails because of invalid container id
 			failure: true,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_notfound",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "postgres:12-alpine",
 				Name:        "notfound",
 				Number:      1,
-				Ports:       []string{"5432:5432"},
-			},
-		},
-		{
-			failure: true,
-			logs:    new(library.Log),
-			container: &pipeline.Container{
-				ID:          "service_github_octocat_1_postgres",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "postgres:12-alpine",
-				Name:        "postgres",
-				Number:      0,
 				Ports:       []string{"5432:5432"},
 			},
 		},

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -111,6 +111,9 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 	// close the stage channel at the end
 	defer close(m[s.Name])
 
+	// create a flag to track the build statuses
+	tracker := constants.StatusSuccess
+
 	logger.Debug("starting execution of stage")
 	// execute the steps for the stage
 	for _, step := range s.Steps {
@@ -119,7 +122,7 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 			Branch: b.GetBranch(),
 			Event:  b.GetEvent(),
 			Repo:   r.GetFullName(),
-			Status: b.GetStatus(),
+			Status: tracker,
 		}
 
 		// when tag event add tag information into ruledata
@@ -163,6 +166,8 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 			if !step.Ruleset.Continue {
 				// set build status to failure
 				b.SetStatus(constants.StatusFailure)
+
+				tracker = constants.StatusFailure
 			}
 
 			// update the step fields

--- a/executor/linux/step_test.go
+++ b/executor/linux/step_test.go
@@ -351,12 +351,12 @@ func TestLinux_StreamStep(t *testing.T) {
 		logs      *library.Log
 		container *pipeline.Container
 	}{
-		{
+		{ // container step succeeds
 			failure: false,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "#init",
 				Name:        "init",
@@ -364,12 +364,12 @@ func TestLinux_StreamStep(t *testing.T) {
 				Pull:        true,
 			},
 		},
-		{
+		{ // container step fails because of nil logs
 			failure: true,
 			logs:    nil,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "target/vela-git:v0.3.0",
 				Name:        "clone",
@@ -377,29 +377,16 @@ func TestLinux_StreamStep(t *testing.T) {
 				Pull:        true,
 			},
 		},
-		{
+		{ // container step fails because of invalid container id
 			failure: true,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_notfound",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "target/vela-git:v0.3.0",
 				Name:        "notfound",
 				Number:      2,
-				Pull:        true,
-			},
-		},
-		{
-			failure: true,
-			logs:    new(library.Log),
-			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "clone",
-				Number:      0,
 				Pull:        true,
 			},
 		},


### PR DESCRIPTION
This PR contains various bug fixes/enhancements to the following:

* Fail pipelines when you're unable to pull external secrets
* defer step/service log updates when streaming logs
* Only set build from running to success when the build has finished executing