### PR TITLE
fix: shared secrets can be in any org

### DIFF
--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -308,7 +308,7 @@ func (s *secretSvc) pull(secret *pipeline.Secret) (*library.Secret, error) {
 
 	// handle shared secrets
 	case constants.SecretShared:
-		org, team, key, err := secret.ParseShared(s.client.repo.GetOrg())
+		org, team, key, err := secret.ParseShared()
 		if err != nil {
 			return nil, err
 		}

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -426,17 +426,6 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // failure with invalid shared secret
-			failure: true,
-			secret: &pipeline.Secret{
-				Name:   "foo",
-				Value:  "bar",
-				Key:    "foo/foo/foo/foo",
-				Engine: "native",
-				Type:   "shared",
-				Origin: &pipeline.Container{},
-			},
-		},
 		{ // failure with shared secret key not found
 			failure: true,
 			secret: &pipeline.Secret{

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-vela/mock v0.5.0-rc1
 	github.com/go-vela/pkg-runtime v0.5.0-rc1.0.20200805191211-be84584fb396
 	github.com/go-vela/sdk-go v0.5.0-rc1
-	github.com/go-vela/types v0.5.0-rc1.0.20200803141719-70581652958d
+	github.com/go-vela/types v0.5.0-rc1.0.20200811203450-36ee799c3884
 	github.com/google/go-cmp v0.5.0
 	github.com/joho/godotenv v1.3.0
 	github.com/onsi/gomega v1.7.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-vela/mock v0.5.0-rc1
 	github.com/go-vela/pkg-runtime v0.5.0-rc1.0.20200805191211-be84584fb396
 	github.com/go-vela/sdk-go v0.5.0-rc1
-	github.com/go-vela/types v0.5.0-rc1.0.20200811203450-36ee799c3884
+	github.com/go-vela/types v0.5.0-rc1.0.20200812124710-1657f6b31ab7
 	github.com/google/go-cmp v0.5.0
 	github.com/joho/godotenv v1.3.0
 	github.com/onsi/gomega v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/go-vela/sdk-go v0.5.0-rc1 h1:v8GtUtL08y6Gx81bY2oYskaMSqyEcJNYqvR5xn7t
 github.com/go-vela/sdk-go v0.5.0-rc1/go.mod h1:BKyGRqJZGPEzRQL5aSVGxZLRF2CSI3QcfeW8wUwRlks=
 github.com/go-vela/types v0.5.0-rc1 h1:klHH5hYGb6JU+01gJxCgSe6d6DxxeU3FSpd9VjeLXNM=
 github.com/go-vela/types v0.5.0-rc1/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
-github.com/go-vela/types v0.5.0-rc1.0.20200803141719-70581652958d h1:UslLlfg9F7YcP5QSSRbgT3uq5P5p+GYuVPwZSpvzTjg=
-github.com/go-vela/types v0.5.0-rc1.0.20200803141719-70581652958d/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
+github.com/go-vela/types v0.5.0-rc1.0.20200811203450-36ee799c3884 h1:ShiOgKDqB8ty96venSDHyfngt1JirMrBRCxG3OJ2Yok=
+github.com/go-vela/types v0.5.0-rc1.0.20200811203450-36ee799c3884/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/go-vela/sdk-go v0.5.0-rc1 h1:v8GtUtL08y6Gx81bY2oYskaMSqyEcJNYqvR5xn7t
 github.com/go-vela/sdk-go v0.5.0-rc1/go.mod h1:BKyGRqJZGPEzRQL5aSVGxZLRF2CSI3QcfeW8wUwRlks=
 github.com/go-vela/types v0.5.0-rc1 h1:klHH5hYGb6JU+01gJxCgSe6d6DxxeU3FSpd9VjeLXNM=
 github.com/go-vela/types v0.5.0-rc1/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
-github.com/go-vela/types v0.5.0-rc1.0.20200811203450-36ee799c3884 h1:ShiOgKDqB8ty96venSDHyfngt1JirMrBRCxG3OJ2Yok=
-github.com/go-vela/types v0.5.0-rc1.0.20200811203450-36ee799c3884/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
+github.com/go-vela/types v0.5.0-rc1.0.20200812124710-1657f6b31ab7 h1:XREWNN5XdAVhrdVlefeTYlKRHHYxg4c5N7Qgzuwre/4=
+github.com/go-vela/types v0.5.0-rc1.0.20200812124710-1657f6b31ab7/go.mod h1:qh+elSsJ5TrUItJw+HoEHfOUWs0lqkJuABuSTgp7fZQ=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=


### PR DESCRIPTION
Update for new types function:
https://github.com/go-vela/types/pull/96