### PR TITLE
fix: uploading image content in init logs

### DIFF
--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -397,7 +397,7 @@ func (c *client) loadStepLogs(name string) (*library.Log, error) {
 
 // loadInitContainer is a helper function to capture
 // the init step from the client.
-func (c *client) loadInitContainer(p *pipeline.Build) (*pipeline.Container, error) {
+func (c *client) loadInitContainer(p *pipeline.Build) *pipeline.Container {
 
 	// TODO: make this better
 	init := new(pipeline.Container)
@@ -410,5 +410,5 @@ func (c *client) loadInitContainer(p *pipeline.Build) (*pipeline.Container, erro
 		init = p.Stages[0].Steps[0]
 	}
 
-	return init, nil
+	return init
 }


### PR DESCRIPTION
Currently, we're seeing behavior from the worker where some of the logs that are supposed to be uploaded in the `init` step are skipped.

The `init` step itself is responsible for performing a number of actions before executing the pipeline like creating pipeline resources on the host, fetching secrets etc.

Most of these actions can be found marked with a `>` character in the logs:

```sh
> Inspecting runtime network...
> Inspecting runtime volume...
> Pulling secrets...
> Pulling service images...
> Pulling stage images...
> Pulling step images...
> Pulling secret images...
```

The specific actions we seem to be missing logs for are the `Pulling <resource> images...` sections 👍 

This PR adds a `defer` block to ensure we upload those logs to the `init` step.