### PR TITLE
feat(executor): add shell for local pkg

### DIFF
--- a/executor/local/api.go
+++ b/executor/local/api.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+// GetBuild gets the current build in execution.
+func (c *client) GetBuild() (*library.Build, error) {
+	return nil, nil
+}
+
+// GetPipeline gets the current pipeline in execution.
+func (c *client) GetPipeline() (*pipeline.Build, error) {
+	return nil, nil
+}
+
+// GetRepo gets the current repo in execution.
+func (c *client) GetRepo() (*library.Repo, error) {
+	return nil, nil
+}
+
+// CancelBuild cancels the current build in execution.
+func (c *client) CancelBuild() (*library.Build, error) {
+	return nil, nil
+}

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"context"
+)
+
+// CreateBuild configures the build for execution.
+func (c *client) CreateBuild(ctx context.Context) error {
+	return nil
+}
+
+// PlanBuild prepares the build for execution.
+func (c *client) PlanBuild(ctx context.Context) error {
+	return nil
+}
+
+// AssembleBuild prepares the containers within a build for execution.
+func (c *client) AssembleBuild(ctx context.Context) error {
+	return nil
+}
+
+// ExecBuild runs a pipeline for a build.
+func (c *client) ExecBuild(ctx context.Context) error {
+	return nil
+}
+
+// DestroyBuild cleans up the build after execution.
+func (c *client) DestroyBuild(ctx context.Context) error {
+	return nil
+}

--- a/executor/local/doc.go
+++ b/executor/local/doc.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// Package local provides the ability for Vela to
+// integrate with the local system.
+//
+// Usage:
+//
+// 	import "github.com/go-vela/worker/executor/local"
+package local

--- a/executor/local/local.go
+++ b/executor/local/local.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+type (
+	// client manages communication with the build resources
+	client struct{}
+
+	svc struct{}
+)
+
+// New returns an Executor implementation that integrates with a Linux instance.
+func New(opts ...Opt) (*client, error) {
+	return nil, nil
+}

--- a/executor/local/opts.go
+++ b/executor/local/opts.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"github.com/go-vela/pkg-runtime/runtime"
+
+	"github.com/go-vela/sdk-go/vela"
+
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+// Opt represents a configuration option to initialize the client.
+type Opt func(*client) error
+
+// WithBuild sets the library build in the client.
+func WithBuild(b *library.Build) Opt {
+	return func(c *client) error {
+		return nil
+	}
+}
+
+// WithHostname sets the hostname in the client.
+func WithHostname(hostname string) Opt {
+	return func(c *client) error {
+		return nil
+	}
+}
+
+// WithPipeline sets the pipeline build in the client.
+func WithPipeline(p *pipeline.Build) Opt {
+	return func(c *client) error {
+		return nil
+	}
+}
+
+// WithRepo sets the library repo in the client.
+func WithRepo(r *library.Repo) Opt {
+	return func(c *client) error {
+		return nil
+	}
+}
+
+// WithRuntime sets the runtime engine in the client.
+func WithRuntime(r runtime.Engine) Opt {
+	return func(c *client) error {
+		return nil
+	}
+}
+
+// WithUser sets the library user in the client.
+func WithUser(u *library.User) Opt {
+	return func(c *client) error {
+		return nil
+	}
+}
+
+// WithVelaClient sets the Vela client in the client.
+func WithVelaClient(cli *vela.Client) Opt {
+	return func(c *client) error {
+		return nil
+	}
+}

--- a/executor/local/secret.go
+++ b/executor/local/secret.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"context"
+
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+// secretSvc handles communication with secret processes during a build.
+type secretSvc svc
+
+// create configures the secret plugin for execution.
+func (s *secretSvc) create(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// destroy cleans up secret plugin after execution.
+func (s *secretSvc) destroy(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// exec runs a secret plugins for a pipeline.
+func (s *secretSvc) exec(ctx context.Context, p *pipeline.SecretSlice) error {
+	return nil
+}
+
+// pull defines a function that pulls the secrets from the server for a given pipeline.
+func (s *secretSvc) pull(secret *pipeline.Secret) (*library.Secret, error) {
+	return nil, nil
+}
+
+// stream tails the output for a secret plugin.
+func (s *secretSvc) stream(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"context"
+
+	"github.com/go-vela/types/pipeline"
+)
+
+// CreateService configures the service for execution.
+func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// PlanService prepares the service for execution.
+func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// ExecService runs a service.
+func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// StreamService tails the output for a service.
+func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// DestroyService cleans up services after execution.
+func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"context"
+
+	"github.com/go-vela/types/pipeline"
+)
+
+// CreateStage prepares the stage for execution.
+func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
+	return nil
+}
+
+// PlanStage prepares the stage for execution.
+func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
+	return nil
+}
+
+// ExecStage runs a stage.
+func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
+	return nil
+}
+
+// DestroyStage cleans up the stage after execution.
+func (c *client) DestroyStage(ctx context.Context, s *pipeline.Stage) error {
+	return nil
+}

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"context"
+
+	"github.com/go-vela/types/pipeline"
+)
+
+// CreateStep configures the step for execution.
+func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// PlanStep prepares the step for execution.
+func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// ExecStep runs a step.
+func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// StreamStep tails the output for a step.
+func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}
+
+// DestroyStep cleans up steps after execution.
+func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error {
+	return nil
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds the "shell" of implementing a new `local` executor.

You'll note that all of these functions `return nil` (or `return nil, nil`) and this is intended for now.

I plan to get all the functions defined, even if they do nothing, and then I'll add the logic to them in subsequent PRs.