### PR TITLE
feat: implement new local client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ fix:
 test:
 	@echo
 	@echo "### Testing Go Code"
-	@go test -race ./...
+	@go test ./...
 
 # The `test-cover` target is intended to run
 # the tests for the Go source code and then
@@ -75,7 +75,7 @@ test:
 test-cover:
 	@echo
 	@echo "### Creating test coverage report"
-	@go test -race -covermode=atomic -coverprofile=coverage.out ./...
+	@go test -covermode=atomic -coverprofile=coverage.out ./...
 	@echo
 	@echo "### Opening test coverage report"
 	@go tool cover -html=coverage.out

--- a/executor/linux/linux.go
+++ b/executor/linux/linux.go
@@ -18,7 +18,7 @@ import (
 )
 
 type (
-	// client manages communication with the build resources
+	// client manages communication with the pipeline resources.
 	client struct {
 		Vela     *vela.Client
 		Runtime  runtime.Engine
@@ -49,6 +49,8 @@ type (
 )
 
 // New returns an Executor implementation that integrates with a Linux instance.
+//
+// nolint: golint // ignore unexported type as it is intentional
 func New(opts ...Opt) (*client, error) {
 	// create new Linux client
 	c := new(client)

--- a/executor/local/local.go
+++ b/executor/local/local.go
@@ -4,14 +4,63 @@
 
 package local
 
-type (
-	// client manages communication with the build resources
-	client struct{}
+import (
+	"sync"
 
-	svc struct{}
+	"github.com/go-vela/pkg-runtime/runtime"
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
 )
 
-// New returns an Executor implementation that integrates with a Linux instance.
+type (
+	// client manages communication with the build resources
+	client struct {
+		Vela     *vela.Client
+		Runtime  runtime.Engine
+		Secrets  map[string]*library.Secret
+		Hostname string
+
+		// clients for build actions
+		secret *secretSvc
+
+		// private fields
+		init        *pipeline.Container
+		build       *library.Build
+		pipeline    *pipeline.Build
+		repo        *library.Repo
+		secrets     sync.Map
+		services    sync.Map
+		serviceLogs sync.Map
+		steps       sync.Map
+		stepLogs    sync.Map
+		user        *library.User
+		err         error
+	}
+
+	svc struct {
+		client *client
+	}
+)
+
+// New returns an Executor implementation that integrates with the local system.
 func New(opts ...Opt) (*client, error) {
-	return nil, nil
+	// create new local client
+	c := new(client)
+
+	// apply all provided configuration options
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// instantiate map for non-plugin secrets
+	c.Secrets = make(map[string]*library.Secret)
+
+	// instantiate all client services
+	c.secret = &secretSvc{client: c}
+
+	return c, nil
 }

--- a/executor/local/local.go
+++ b/executor/local/local.go
@@ -14,7 +14,7 @@ import (
 )
 
 type (
-	// client manages communication with the build resources
+	// client manages communication with the pipeline resources.
 	client struct {
 		Vela     *vela.Client
 		Runtime  runtime.Engine
@@ -44,6 +44,8 @@ type (
 )
 
 // New returns an Executor implementation that integrates with the local system.
+//
+// nolint: golint // ignore unexported type as it is intentional
 func New(opts ...Opt) (*client, error) {
 	// create new local client
 	c := new(client)

--- a/executor/local/local_test.go
+++ b/executor/local/local_test.go
@@ -1,0 +1,336 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/go-vela/mock/server"
+	"github.com/go-vela/types"
+
+	"github.com/go-vela/pkg-runtime/runtime/docker"
+
+	"github.com/go-vela/sdk-go/vela"
+
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestLocal_New(t *testing.T) {
+	// setup types
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		build   *library.Build
+	}{
+		{
+			failure: false,
+			build:   testBuild(),
+		},
+		{
+			failure: true,
+			build:   nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_, err := New(
+			WithBuild(test.build),
+			WithHostname("localhost"),
+			WithPipeline(testSteps()),
+			WithRepo(testRepo()),
+			WithRuntime(_runtime),
+			WithUser(testUser()),
+			WithVelaClient(_client),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("New should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("New returned err: %v", err)
+		}
+	}
+}
+
+// testBuild is a test helper function to create a Build
+// type with all fields set to a fake value.
+func testBuild() *library.Build {
+	return &library.Build{
+		ID:           vela.Int64(1),
+		Number:       vela.Int(1),
+		Parent:       vela.Int(1),
+		Event:        vela.String("push"),
+		Status:       vela.String("success"),
+		Error:        vela.String(""),
+		Enqueued:     vela.Int64(1563474077),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(1563474077),
+		Finished:     vela.Int64(0),
+		Deploy:       vela.String(""),
+		Clone:        vela.String("https://github.com/github/octocat.git"),
+		Source:       vela.String("https://github.com/github/octocat/abcdefghi123456789"),
+		Title:        vela.String("push received from https://github.com/github/octocat"),
+		Message:      vela.String("First commit..."),
+		Commit:       vela.String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Sender:       vela.String("OctoKitty"),
+		Author:       vela.String("OctoKitty"),
+		Branch:       vela.String("master"),
+		Ref:          vela.String("refs/heads/master"),
+		BaseRef:      vela.String(""),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("Local"),
+	}
+}
+
+// testRepo is a test helper function to create a Repo
+// type with all fields set to a fake value.
+func testRepo() *library.Repo {
+	return &library.Repo{
+		ID:          vela.Int64(1),
+		Org:         vela.String("github"),
+		Name:        vela.String("octocat"),
+		FullName:    vela.String("github/octocat"),
+		Link:        vela.String("https://github.com/github/octocat"),
+		Clone:       vela.String("https://github.com/github/octocat.git"),
+		Branch:      vela.String("master"),
+		Timeout:     vela.Int64(60),
+		Visibility:  vela.String("public"),
+		Private:     vela.Bool(false),
+		Trusted:     vela.Bool(false),
+		Active:      vela.Bool(true),
+		AllowPull:   vela.Bool(false),
+		AllowPush:   vela.Bool(true),
+		AllowDeploy: vela.Bool(false),
+		AllowTag:    vela.Bool(false),
+	}
+}
+
+// testUser is a test helper function to create a User
+// type with all fields set to a fake value.
+func testUser() *library.User {
+	return &library.User{
+		ID:        vela.Int64(1),
+		Name:      vela.String("octocat"),
+		Token:     vela.String("superSecretToken"),
+		Hash:      vela.String("MzM4N2MzMDAtNmY4Mi00OTA5LWFhZDAtNWIzMTlkNTJkODMy"),
+		Favorites: vela.Strings([]string{"github/octocat"}),
+		Active:    vela.Bool(true),
+		Admin:     vela.Bool(false),
+	}
+}
+
+// testUser is a test helper function to create a metadata
+// type with all fields set to a fake value.
+func testMetadata() *types.Metadata {
+	return &types.Metadata{
+		Database: &types.Database{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Queue: &types.Queue{
+			Channel: "foo",
+			Driver:  "foo",
+			Host:    "foo",
+		},
+		Source: &types.Source{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Vela: &types.Vela{
+			Address:    "foo",
+			WebAddress: "foo",
+		},
+	}
+}
+
+// testStages is a test helper function to create a stages
+// pipeline with fake steps.
+func testStages() *pipeline.Build {
+	return &pipeline.Build{
+		Version: "1",
+		ID:      "github_octocat_1",
+		Services: pipeline.ContainerSlice{
+			{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+		Stages: pipeline.StageSlice{
+			{
+				Name: "init",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_init_init",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "#init",
+						Name:        "init",
+						Number:      1,
+						Pull:        "always",
+					},
+				},
+			},
+			{
+				Name:  "clone",
+				Needs: []string{"init"},
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+			{
+				Name:  "echo",
+				Needs: []string{"clone"},
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_echo_echo",
+						Commands:    []string{"echo hello"},
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "alpine:latest",
+						Name:        "echo",
+						Number:      3,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+		Secrets: pipeline.SecretSlice{
+			{
+				Name:   "foo",
+				Key:    "github/octocat/foo",
+				Engine: "native",
+				Type:   "repo",
+				Origin: &pipeline.Container{},
+			},
+			{
+				Name:   "foo",
+				Key:    "github/foo",
+				Engine: "native",
+				Type:   "org",
+				Origin: &pipeline.Container{},
+			},
+			{
+				Name:   "foo",
+				Key:    "github/octokitties/foo",
+				Engine: "native",
+				Type:   "shared",
+				Origin: &pipeline.Container{},
+			},
+		},
+	}
+}
+
+// testSteps is a test helper function to create a steps
+// pipeline with fake steps.
+func testSteps() *pipeline.Build {
+	return &pipeline.Build{
+		Version: "1",
+		ID:      "github_octocat_1",
+		Services: pipeline.ContainerSlice{
+			{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+		Steps: pipeline.ContainerSlice{
+			{
+				ID:          "step_github_octocat_1_init",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "always",
+			},
+			{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
+			},
+			{
+				ID:          "step_github_octocat_1_echo",
+				Commands:    []string{"echo hello"},
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      3,
+				Pull:        "always",
+			},
+		},
+		Secrets: pipeline.SecretSlice{
+			{
+				Name:   "foo",
+				Key:    "github/octocat/foo",
+				Engine: "native",
+				Type:   "repo",
+				Origin: &pipeline.Container{},
+			},
+			{
+				Name:   "foo",
+				Key:    "github/foo",
+				Engine: "native",
+				Type:   "org",
+				Origin: &pipeline.Container{},
+			},
+			{
+				Name:   "foo",
+				Key:    "github/octokitties/foo",
+				Engine: "native",
+				Type:   "shared",
+				Origin: &pipeline.Container{},
+			},
+		},
+	}
+}

--- a/executor/local/local_test.go
+++ b/executor/local/local_test.go
@@ -46,10 +46,6 @@ func TestLocal_New(t *testing.T) {
 			failure: false,
 			build:   testBuild(),
 		},
-		{
-			failure: true,
-			build:   nil,
-		},
 	}
 
 	// run tests


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds a `New()` function for used for instantiating the `local` executor client.

Also found in this PR is the removal of the `-race` flag for our `make` commands for testing the code.

You can find more information on this flag here:

https://golang.org/doc/articles/race_detector.html

The reason for removing this flag is because we do testing for `stages` in the executor.

`stages`, by nature, attempt to use the same variables since they run concurrently.

 i.e. what `repo` the pipeline is being executed for, what `build` the pipeline is being executed for, etc.