### PR TITLE
feat: add local client options

### DIFF
--- a/executor/local/local_test.go
+++ b/executor/local/local_test.go
@@ -46,6 +46,10 @@ func TestLocal_New(t *testing.T) {
 			failure: false,
 			build:   testBuild(),
 		},
+		{
+			failure: true,
+			build:   nil,
+		},
 	}
 
 	// run tests

--- a/executor/local/opts.go
+++ b/executor/local/opts.go
@@ -5,6 +5,8 @@
 package local
 
 import (
+	"fmt"
+
 	"github.com/go-vela/pkg-runtime/runtime"
 
 	"github.com/go-vela/sdk-go/vela"
@@ -19,6 +21,14 @@ type Opt func(*client) error
 // WithBuild sets the library build in the client.
 func WithBuild(b *library.Build) Opt {
 	return func(c *client) error {
+		// check if the build provided is empty
+		if b == nil {
+			return fmt.Errorf("empty build provided")
+		}
+
+		// set the build in the client
+		c.build = b
+
 		return nil
 	}
 }
@@ -26,6 +36,15 @@ func WithBuild(b *library.Build) Opt {
 // WithHostname sets the hostname in the client.
 func WithHostname(hostname string) Opt {
 	return func(c *client) error {
+		// check if a hostname is provided
+		if len(hostname) == 0 {
+			// default the hostname to localhost
+			hostname = "localhost"
+		}
+
+		// set the hostname in the client
+		c.Hostname = hostname
+
 		return nil
 	}
 }
@@ -33,6 +52,14 @@ func WithHostname(hostname string) Opt {
 // WithPipeline sets the pipeline build in the client.
 func WithPipeline(p *pipeline.Build) Opt {
 	return func(c *client) error {
+		// check if the pipeline provided is empty
+		if p == nil {
+			return fmt.Errorf("empty pipeline provided")
+		}
+
+		// set the pipeline in the client
+		c.pipeline = p
+
 		return nil
 	}
 }
@@ -40,6 +67,14 @@ func WithPipeline(p *pipeline.Build) Opt {
 // WithRepo sets the library repo in the client.
 func WithRepo(r *library.Repo) Opt {
 	return func(c *client) error {
+		// check if the repo provided is empty
+		if r == nil {
+			return fmt.Errorf("empty repo provided")
+		}
+
+		// set the repo in the client
+		c.repo = r
+
 		return nil
 	}
 }
@@ -47,6 +82,14 @@ func WithRepo(r *library.Repo) Opt {
 // WithRuntime sets the runtime engine in the client.
 func WithRuntime(r runtime.Engine) Opt {
 	return func(c *client) error {
+		// check if the runtime provided is empty
+		if r == nil {
+			return fmt.Errorf("empty runtime provided")
+		}
+
+		// set the runtime in the client
+		c.Runtime = r
+
 		return nil
 	}
 }
@@ -54,6 +97,14 @@ func WithRuntime(r runtime.Engine) Opt {
 // WithUser sets the library user in the client.
 func WithUser(u *library.User) Opt {
 	return func(c *client) error {
+		// check if the user provided is empty
+		if u == nil {
+			return fmt.Errorf("empty user provided")
+		}
+
+		// set the user in the client
+		c.user = u
+
 		return nil
 	}
 }
@@ -61,6 +112,14 @@ func WithUser(u *library.User) Opt {
 // WithVelaClient sets the Vela client in the client.
 func WithVelaClient(cli *vela.Client) Opt {
 	return func(c *client) error {
+		// check if the Vela client provided is empty
+		if cli == nil {
+			return fmt.Errorf("empty Vela client provided")
+		}
+
+		// set the Vela client in the client
+		c.Vela = cli
+
 		return nil
 	}
 }

--- a/executor/local/opts_test.go
+++ b/executor/local/opts_test.go
@@ -1,0 +1,322 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/go-vela/mock/server"
+
+	"github.com/go-vela/pkg-runtime/runtime"
+	"github.com/go-vela/pkg-runtime/runtime/docker"
+
+	"github.com/go-vela/sdk-go/vela"
+
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestLocal_Opt_WithBuild(t *testing.T) {
+	// setup types
+	_build := testBuild()
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		build   *library.Build
+	}{
+		{
+			failure: false,
+			build:   _build,
+		},
+		{
+			failure: true,
+			build:   nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(test.build),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithBuild should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithBuild returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.build, _build) {
+			t.Errorf("WithBuild is %v, want %v", _engine.build, _build)
+		}
+	}
+}
+
+func TestLocal_Opt_WithHostname(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		hostname string
+		want     string
+	}{
+		{
+			hostname: "vela.worker.localhost",
+			want:     "vela.worker.localhost",
+		},
+		{
+			hostname: "",
+			want:     "localhost",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithHostname(test.hostname),
+		)
+		if err != nil {
+			t.Errorf("unable to create Local engine: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.Hostname, test.want) {
+			t.Errorf("WithHostname is %v, want %v", _engine.Hostname, test.want)
+		}
+	}
+}
+
+func TestLocal_Opt_WithPipeline(t *testing.T) {
+	// setup types
+	_steps := testSteps()
+
+	// setup tests
+	tests := []struct {
+		failure  bool
+		pipeline *pipeline.Build
+	}{
+		{
+			failure:  false,
+			pipeline: _steps,
+		},
+		{
+			failure:  true,
+			pipeline: nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithPipeline(test.pipeline),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithPipeline should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithPipeline returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.pipeline, _steps) {
+			t.Errorf("WithPipeline is %v, want %v", _engine.pipeline, _steps)
+		}
+	}
+}
+
+func TestLocal_Opt_WithRepo(t *testing.T) {
+	// setup types
+	_repo := testRepo()
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		repo    *library.Repo
+	}{
+		{
+			failure: false,
+			repo:    _repo,
+		},
+		{
+			failure: true,
+			repo:    nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithRepo(test.repo),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithRepo should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithRepo returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.repo, _repo) {
+			t.Errorf("WithRepo is %v, want %v", _engine.repo, _repo)
+		}
+	}
+}
+
+func TestLocal_Opt_WithRuntime(t *testing.T) {
+	// setup types
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		runtime runtime.Engine
+	}{
+		{
+			failure: false,
+			runtime: _runtime,
+		},
+		{
+			failure: true,
+			runtime: nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithRuntime(test.runtime),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithRuntime should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithRuntime returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.Runtime, _runtime) {
+			t.Errorf("WithRuntime is %v, want %v", _engine.Runtime, _runtime)
+		}
+	}
+}
+
+func TestLocal_Opt_WithUser(t *testing.T) {
+	// setup types
+	_user := testUser()
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		user    *library.User
+	}{
+		{
+			failure: false,
+			user:    _user,
+		},
+		{
+			failure: true,
+			user:    nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithUser(test.user),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithUser should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithUser returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.user, _user) {
+			t.Errorf("WithUser is %v, want %v", _engine.user, _user)
+		}
+	}
+}
+
+func TestLocal_Opt_WithVelaClient(t *testing.T) {
+	// setup types
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		client  *vela.Client
+	}{
+		{
+			failure: false,
+			client:  _client,
+		},
+		{
+			failure: true,
+			client:  nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithVelaClient(test.client),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithVelaClient should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithVelaClient returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.Vela, _client) {
+			t.Errorf("WithVelaClient is %v, want %v", _engine.Vela, _client)
+		}
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This implements a set of functions for populating specific values in the `local` executor client.

The functions that are being implemented:

* `WithBuild()`
* `WithHostname()`
* `WithPipeline()`
* `WithRepo()`
* `WithRuntime()`
* `WithUser()`
* `WithVelaClient()`

Most, if not all, of these functions will be used to set specific information when we attempt to execute a build locally.

That being said, it's worth mentioning that some of these functions may end up getting removed in the future once more pieces of how a build will be ran locally are ironed out.

I'm replicating as much of the `linux` executor as I think we'll need initially so I can get a functional example up and running.

Once that's complete, I plan to go back and refactor some or most of the package to only include the code we want/need 👍 