### PR TITLE
feat(local): add logic for handling services

### DIFF
--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -5,32 +5,338 @@
 package local
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
 
+	"github.com/drone/envsubst"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
 )
 
 // CreateService configures the service for execution.
 func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) error {
+	ctn.Environment["BUILD_HOST"] = c.Hostname
+	ctn.Environment["VELA_HOST"] = c.Hostname
+	ctn.Environment["VELA_VERSION"] = "v0.6.0"
+	// TODO: remove hardcoded reference
+	ctn.Environment["VELA_RUNTIME"] = "docker"
+	ctn.Environment["VELA_DISTRIBUTION"] = "linux"
+
+	// setup the runtime container
+	err := c.Runtime.SetupContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+
+	// TODO: will be uncommented in a future PR
+	// // inject secrets for container
+	// err = injectSecrets(ctn, c.Secrets)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// marshal container configuration
+	body, err := json.Marshal(ctn)
+	if err != nil {
+		return fmt.Errorf("unable to marshal configuration: %v", err)
+	}
+
+	// create substitute function
+	subFunc := func(name string) string {
+		env := ctn.Environment[name]
+		if strings.Contains(env, "\n") {
+			env = fmt.Sprintf("%q", env)
+		}
+
+		return env
+	}
+
+	// substitute the environment variables
+	//
+	// https://pkg.go.dev/github.com/drone/envsubst?tab=doc#Eval
+	subStep, err := envsubst.Eval(string(body), subFunc)
+	if err != nil {
+		return fmt.Errorf("unable to substitute environment variables: %v", err)
+	}
+
+	// unmarshal container configuration
+	err = json.Unmarshal([]byte(subStep), ctn)
+	if err != nil {
+		// define a new buffer to capture the output, which doesn't need to be written
+		buf := new(bytes.Buffer)
+
+		// create new encoder for buffer
+		enc := json.NewEncoder(buf)
+		// ctn is modified via pointer through enc.Encode
+		err = enc.Encode(ctn)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal configuration: %v", err)
+		}
+	}
+
 	return nil
 }
 
 // PlanService prepares the service for execution.
 func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error {
+	var err error
+
+	b := c.build
+	r := c.repo
+
+	// update the engine service object
+	s := new(library.Service)
+	s.SetName(ctn.Name)
+	s.SetNumber(ctn.Number)
+	s.SetStatus(constants.StatusRunning)
+	s.SetStarted(time.Now().UTC().Unix())
+	s.SetHost(ctn.Environment["VELA_HOST"])
+	s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+	s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+
+	// send API call to update the service
+	//
+	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#SvcService.Update
+	s, _, err = c.Vela.Svc.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+	if err != nil {
+		return err
+	}
+
+	s.SetStatus(constants.StatusSuccess)
+
+	// add a service to a map
+	c.services.Store(ctn.ID, s)
+
+	// send API call to capture the service log
+	//
+	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.GetService
+	l, _, err := c.Vela.Log.GetService(r.GetOrg(), r.GetName(), b.GetNumber(), s.GetNumber())
+	if err != nil {
+		return err
+	}
+
+	// add a service log to a map
+	c.serviceLogs.Store(ctn.ID, l)
+
 	return nil
 }
 
 // ExecService runs a service.
 func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error {
+	// run the runtime container
+	err := c.Runtime.RunContainer(ctx, ctn, c.pipeline)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		// stream logs from container
+		err := c.StreamService(ctx, ctn)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+		}
+	}()
+
 	return nil
 }
 
 // StreamService tails the output for a service.
 func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) error {
-	return nil
+	b := c.build
+	r := c.repo
+
+	// load the logs for the service from the client
+	l, err := c.loadServiceLogs(ctn.ID)
+	if err != nil {
+		return err
+	}
+
+	// create new buffer for uploading logs
+	logs := new(bytes.Buffer)
+
+	defer func() {
+		// tail the runtime container
+		rc, err := c.Runtime.TailContainer(ctx, ctn)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+
+			return
+		}
+		defer rc.Close()
+
+		// read all output from the runtime container
+		data, err := ioutil.ReadAll(rc)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+
+			return
+		}
+
+		// overwrite the existing log with all bytes
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.SetData
+		l.SetData(data)
+
+		// send API call to update the logs for the service
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
+		_, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+		}
+	}()
+
+	// tail the runtime container
+	rc, err := c.Runtime.TailContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	// create new scanner from the container output
+	scanner := bufio.NewScanner(rc)
+
+	// scan entire container output
+	for scanner.Scan() {
+		// write all the logs from the scanner
+		logs.Write(append(scanner.Bytes(), []byte("\n")...))
+
+		// if we have at least 1000 bytes in our buffer
+		if logs.Len() > 1000 {
+			// update the existing log with the new bytes
+			//
+			// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+			l.AppendData(logs.Bytes())
+
+			// send API call to append the logs for the service
+			//
+			// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
+			l, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+			if err != nil {
+				return err
+			}
+
+			// flush the buffer of logs
+			logs.Reset()
+		}
+	}
+
+	return scanner.Err()
 }
 
 // DestroyService cleans up services after execution.
 func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) error {
+	// load the service from the client
+	service, err := c.loadService(ctn.ID)
+	if err != nil {
+		// create the service from the container
+		service = new(library.Service)
+		service.SetName(ctn.Name)
+		service.SetNumber(ctn.Number)
+		service.SetStatus(constants.StatusPending)
+		service.SetHost(ctn.Environment["VELA_HOST"])
+		service.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+		service.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+	}
+
+	defer func() {
+		// send API call to update the step
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#SvcService.Update
+		_, _, err := c.Vela.Svc.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), service)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+		}
+	}()
+
+	// check if the service is in a pending state
+	if service.GetStatus() == constants.StatusPending {
+		// update the service fields
+		service.SetExitCode(137)
+		service.SetFinished(time.Now().UTC().Unix())
+		service.SetStatus(constants.StatusKilled)
+
+		// check if the service was not started
+		if service.GetStarted() == 0 {
+			// set the started time to the finished time
+			service.SetStarted(service.GetFinished())
+		}
+	}
+
+	// inspect the runtime container
+	err = c.Runtime.InspectContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+
+	// check if the service finished
+	if service.GetFinished() == 0 {
+		// update the service fields
+		service.SetFinished(time.Now().UTC().Unix())
+		service.SetStatus(constants.StatusSuccess)
+
+		// check the container for an unsuccessful exit code
+		if ctn.ExitCode > 0 {
+			// update the service fields
+			service.SetExitCode(ctn.ExitCode)
+			service.SetStatus(constants.StatusFailure)
+		}
+	}
+
+	// remove the runtime container
+	err = c.Runtime.RemoveContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// loadService is a helper function to capture
+// a service from the client.
+func (c *client) loadService(name string) (*library.Service, error) {
+	// load the service key from the client
+	result, ok := c.services.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("unable to load service %s", name)
+	}
+
+	// cast the service key to the expected type
+	s, ok := result.(*library.Service)
+	if !ok {
+		return nil, fmt.Errorf("service %s had unexpected value", name)
+	}
+
+	return s, nil
+}
+
+// loadServiceLog is a helper function to capture
+// the logs for a service from the client.
+func (c *client) loadServiceLogs(name string) (*library.Log, error) {
+	// load the service log key from the client
+	result, ok := c.serviceLogs.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("unable to load logs for service %s", name)
+	}
+
+	// cast the service log key to the expected type
+	l, ok := result.(*library.Log)
+	if !ok {
+		return nil, fmt.Errorf("logs for service %s had unexpected value", name)
+	}
+
+	return l, nil
 }

--- a/executor/local/service_test.go
+++ b/executor/local/service_test.go
@@ -1,0 +1,665 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/go-vela/mock/server"
+
+	"github.com/go-vela/pkg-runtime/runtime/docker"
+
+	"github.com/go-vela/sdk-go/vela"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestLocal_CreateService(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		container *pipeline.Container
+	}{
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:notfound",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:        "service_github_octocat_1_postgres",
+				Commands:  []string{"echo", "${BAR}", "${FOO}"},
+				Directory: "/home/github/octocat",
+				Environment: map[string]string{
+					"BAR": "1\n2\n",
+					"FOO": "!@#$%^&*()\\",
+				},
+				Image:  "postgres:12-alpine",
+				Name:   "postgres",
+				Number: 1,
+				Ports:  []string{"5432:5432"},
+				Pull:   "not_present",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		err = _engine.CreateService(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateService returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_PlanService(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		container *pipeline.Container
+	}{
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      0,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		err = _engine.PlanService(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("PlanService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("PlanService returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_ExecService(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		container *pipeline.Container
+	}{
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_notfound",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "notfound",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		_engine.serviceLogs.Store(test.container.ID, new(library.Log))
+		_engine.services.Store(test.container.ID, new(library.Service))
+
+		err = _engine.ExecService(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("ExecService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("ExecService returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_StreamService(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		logs      *library.Log
+		container *pipeline.Container
+	}{
+		{ // container step succeeds
+			failure: false,
+			logs:    new(library.Log),
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+		{ // container step fails because of nil logs
+			failure: true,
+			logs:    nil,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+		{ // container step fails because of invalid container id
+			failure: true,
+			logs:    new(library.Log),
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_notfound",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "notfound",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		if test.logs != nil {
+			_engine.serviceLogs.Store(test.container.ID, test.logs)
+		}
+
+		_engine.services.Store(test.container.ID, new(library.Service))
+
+		err = _engine.StreamService(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("StreamService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("StreamService returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_DestroyService(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	_service := new(library.Service)
+	_service.SetName("postgres")
+	_service.SetNumber(1)
+	_service.SetStatus(constants.StatusPending)
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		container *pipeline.Container
+		service   *library.Service
+	}{
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+			service: _service,
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_notfound",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "notfound",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+			service: new(library.Service),
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "service_github_octocat_1_ignorenotfound",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "ignorenotfound",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
+			},
+			service: new(library.Service),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		_engine.services.Store(test.container.ID, test.service)
+
+		err = _engine.DestroyService(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DestroyService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DestroyService returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_loadService(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		name    string
+		value   interface{}
+	}{
+		{
+			failure: false,
+			name:    "service_github_octocat_1_init",
+			value:   new(library.Service),
+		},
+		{
+			failure: true,
+			name:    "service_github_octocat_1_init",
+			value:   nil,
+		},
+		{
+			failure: true,
+			name:    "service_github_octocat_1_init",
+			value:   new(library.Log),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		if test.value != nil {
+			_engine.services.Store(test.name, test.value)
+		}
+
+		_, err = _engine.loadService(test.name)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("loadService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("loadService returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_loadServiceLogs(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		name    string
+		value   interface{}
+	}{
+		{
+			failure: false,
+			name:    "service_github_octocat_1_init",
+			value:   new(library.Log),
+		},
+		{
+			failure: true,
+			name:    "service_github_octocat_1_init",
+			value:   nil,
+		},
+		{
+			failure: true,
+			name:    "service_github_octocat_1_init",
+			value:   new(library.Service),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		if test.value != nil {
+			_engine.serviceLogs.Store(test.name, test.value)
+		}
+
+		_, err = _engine.loadServiceLogs(test.name)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("loadServiceLogs should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("loadServiceLogs returned err: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This implements a set of functions for dealing with `services` in the `local` executor client.

* `CreateService()`
* `PlanService()`
* `ExecService()`
* `StreamService()`
* `DestroyService()`

This is a stepping stone to getting the `local` executor fully implemented when trying to run a pipeline locally.