### PR TITLE
feat(local): add logic for handling steps

### DIFF
--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -5,32 +5,393 @@
 package local
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
 
+	"github.com/drone/envsubst"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
 )
 
 // CreateStep configures the step for execution.
 func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error {
+	ctn.Environment["BUILD_HOST"] = c.Hostname
+	ctn.Environment["VELA_HOST"] = c.Hostname
+	ctn.Environment["VELA_VERSION"] = "v0.6.0"
+	// TODO: remove hardcoded reference
+	ctn.Environment["VELA_RUNTIME"] = "docker"
+	ctn.Environment["VELA_DISTRIBUTION"] = "linux"
+
+	// TODO: remove hardcoded reference
+	if ctn.Name == "init" {
+		return nil
+	}
+
+	// setup the runtime container
+	err := c.Runtime.SetupContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+
+	// TODO: will be uncommented in a future PR
+	// // inject secrets for container
+	// err = injectSecrets(ctn, c.Secrets)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// marshal container configuration
+	body, err := json.Marshal(ctn)
+	if err != nil {
+		return fmt.Errorf("unable to marshal configuration: %v", err)
+	}
+
+	// create substitute function
+	subFunc := func(name string) string {
+		env := ctn.Environment[name]
+		if strings.Contains(env, "\n") {
+			env = fmt.Sprintf("%q", env)
+		}
+
+		return env
+	}
+
+	// substitute the environment variables
+	//
+	// https://pkg.go.dev/github.com/drone/envsubst?tab=doc#Eval
+	subStep, err := envsubst.Eval(string(body), subFunc)
+	if err != nil {
+		return fmt.Errorf("unable to substitute environment variables: %v", err)
+	}
+
+	// unmarshal container configuration
+	err = json.Unmarshal([]byte(subStep), ctn)
+	if err != nil {
+		// define a new buffer to capture the output, which doesn't need to be written
+		buf := new(bytes.Buffer)
+
+		// create new encoder for buffer
+		enc := json.NewEncoder(buf)
+		// ctn is modified via pointer through enc.Encode
+		err = enc.Encode(ctn)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal configuration: %v", err)
+		}
+	}
+
 	return nil
 }
 
 // PlanStep prepares the step for execution.
 func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
+	var err error
+
+	b := c.build
+	r := c.repo
+
+	// update the engine step object
+	s := new(library.Step)
+	s.SetName(ctn.Name)
+	s.SetNumber(ctn.Number)
+	s.SetStatus(constants.StatusRunning)
+	s.SetStarted(time.Now().UTC().Unix())
+	s.SetHost(ctn.Environment["VELA_HOST"])
+	s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+	s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+
+	// send API call to update the step
+	//
+	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
+	s, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+	if err != nil {
+		return err
+	}
+
+	s.SetStatus(constants.StatusSuccess)
+
+	// add a step to a map
+	c.steps.Store(ctn.ID, s)
+
+	// send API call to capture the step log
+	//
+	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.GetStep
+	l, _, err := c.Vela.Log.GetStep(r.GetOrg(), r.GetName(), b.GetNumber(), s.GetNumber())
+	if err != nil {
+		return err
+	}
+
+	// add a step log to a map
+	c.stepLogs.Store(ctn.ID, l)
+
 	return nil
 }
 
 // ExecStep runs a step.
 func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
+	// TODO: remove hardcoded reference
+	if ctn.Name == "init" {
+		return nil
+	}
+
+	// run the runtime container
+	err := c.Runtime.RunContainer(ctx, ctn, c.pipeline)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		// stream logs from container
+		err := c.StreamStep(ctx, ctn)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+		}
+	}()
+
+	// do not wait for detached containers
+	if ctn.Detach {
+		return nil
+	}
+
+	// wait for the runtime container
+	err = c.Runtime.WaitContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+
+	// inspect the runtime container
+	err = c.Runtime.InspectContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // StreamStep tails the output for a step.
 func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error {
-	return nil
+	// TODO: remove hardcoded reference
+	if ctn.Name == "init" {
+		return nil
+	}
+
+	b := c.build
+	r := c.repo
+
+	// load the logs for the step from the client
+	l, err := c.loadStepLogs(ctn.ID)
+	if err != nil {
+		return err
+	}
+
+	// create new buffer for uploading logs
+	logs := new(bytes.Buffer)
+
+	defer func() {
+		// tail the runtime container
+		rc, err := c.Runtime.TailContainer(ctx, ctn)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+
+			return
+		}
+		defer rc.Close()
+
+		// read all output from the runtime container
+		data, err := ioutil.ReadAll(rc)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+
+			return
+		}
+
+		// overwrite the existing log with all bytes
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.SetData
+		l.SetData(data)
+
+		// send API call to update the logs for the step
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
+		_, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+		}
+	}()
+
+	// tail the runtime container
+	rc, err := c.Runtime.TailContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	// create new scanner from the container output
+	scanner := bufio.NewScanner(rc)
+
+	// scan entire container output
+	for scanner.Scan() {
+		// write all the logs from the scanner
+		logs.Write(append(scanner.Bytes(), []byte("\n")...))
+
+		// if we have at least 1000 bytes in our buffer
+		if logs.Len() > 1000 {
+			// update the existing log with the new bytes
+			//
+			// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+			l.AppendData(logs.Bytes())
+
+			// send API call to append the logs for the step
+			//
+			// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
+			l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+			if err != nil {
+				return err
+			}
+
+			// flush the buffer of logs
+			logs.Reset()
+		}
+	}
+
+	return scanner.Err()
 }
 
 // DestroyStep cleans up steps after execution.
 func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error {
+	// TODO: remove hardcoded reference
+	if ctn.Name == "init" {
+		return nil
+	}
+
+	// load the step from the client
+	step, err := c.loadStep(ctn.ID)
+	if err != nil {
+		// create the step from the container
+		step = new(library.Step)
+		step.SetName(ctn.Name)
+		step.SetNumber(ctn.Number)
+		step.SetStatus(constants.StatusPending)
+		step.SetHost(ctn.Environment["VELA_HOST"])
+		step.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+		step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+	}
+
+	defer func() {
+		// send API call to update the step
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
+		_, _, err := c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), step)
+		if err != nil {
+			// TODO: Should this be changed or removed?
+			fmt.Println(err)
+		}
+	}()
+
+	// check if the step is in a pending state
+	if step.GetStatus() == constants.StatusPending {
+		// update the step fields
+		step.SetExitCode(137)
+		step.SetFinished(time.Now().UTC().Unix())
+		step.SetStatus(constants.StatusKilled)
+
+		// check if the step was not started
+		if step.GetStarted() == 0 {
+			// set the started time to the finished time
+			step.SetStarted(step.GetFinished())
+		}
+	}
+
+	// inspect the runtime container
+	err = c.Runtime.InspectContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+
+	// check if the step finished
+	if step.GetFinished() == 0 {
+		// update the step fields
+		step.SetFinished(time.Now().UTC().Unix())
+		step.SetStatus(constants.StatusSuccess)
+
+		// check the container for an unsuccessful exit code
+		if ctn.ExitCode > 0 {
+			// update the step fields
+			step.SetExitCode(ctn.ExitCode)
+			step.SetStatus(constants.StatusFailure)
+		}
+	}
+
+	// remove the runtime container
+	err = c.Runtime.RemoveContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// loadStep is a helper function to capture
+// a step from the client.
+func (c *client) loadStep(name string) (*library.Step, error) {
+	// load the step key from the client
+	result, ok := c.steps.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("unable to load step %s", name)
+	}
+
+	// cast the step key to the expected type
+	s, ok := result.(*library.Step)
+	if !ok {
+		return nil, fmt.Errorf("step %s had unexpected value", name)
+	}
+
+	return s, nil
+}
+
+// loadStepLog is a helper function to capture
+// the logs for a step from the client.
+func (c *client) loadStepLogs(name string) (*library.Log, error) {
+	// load the step log key from the client
+	result, ok := c.stepLogs.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("unable to load logs for step %s", name)
+	}
+
+	// cast the step log key to the expected type
+	l, ok := result.(*library.Log)
+	if !ok {
+		return nil, fmt.Errorf("logs for step %s had unexpected value", name)
+	}
+
+	return l, nil
+}
+
+// loadInitContainer is a helper function to capture
+// the init step from the client.
+func (c *client) loadInitContainer(p *pipeline.Build) *pipeline.Container {
+
+	// TODO: make this better
+	init := new(pipeline.Container)
+	if len(p.Steps) > 0 {
+		init = p.Steps[0]
+	}
+
+	// TODO: make this better
+	if len(p.Stages) > 0 {
+		init = p.Stages[0].Steps[0]
+	}
+
+	return init
 }

--- a/executor/local/step_test.go
+++ b/executor/local/step_test.go
@@ -1,0 +1,703 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/go-vela/mock/server"
+
+	"github.com/go-vela/pkg-runtime/runtime/docker"
+
+	"github.com/go-vela/sdk-go/vela"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestLocal_CreateStep(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		container *pipeline.Container
+	}{
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_init",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "always",
+			},
+		},
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:notfound",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:        "step_github_octocat_1_clone",
+				Commands:  []string{"echo", "${BAR}", "${FOO}"},
+				Directory: "/home/github/octocat",
+				Environment: map[string]string{
+					"BAR": "1\n2\n",
+					"FOO": "`~!@#$%^&*()-_=+[{]}\\|;:',<.>/?",
+				},
+				Image:  "target/vela-git:v0.3.0",
+				Name:   "clone",
+				Number: 2,
+				Pull:   "always",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		err = _engine.CreateStep(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateStep returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_PlanStep(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		container *pipeline.Container
+	}{
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      0,
+				Pull:        "always",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		err = _engine.PlanStep(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("PlanStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("PlanStep returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_ExecStep(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		container *pipeline.Container
+	}{
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_init",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "always",
+			},
+		},
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_clone",
+				Detach:      true,
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_notfound",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "notfound",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		_engine.stepLogs.Store(test.container.ID, new(library.Log))
+		_engine.steps.Store(test.container.ID, new(library.Step))
+
+		err = _engine.ExecStep(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("ExecStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("ExecStep returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_StreamStep(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		logs      *library.Log
+		container *pipeline.Container
+	}{
+		{ // container step succeeds
+			failure: false,
+			logs:    new(library.Log),
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_init",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "always",
+			},
+		},
+		{ // container step fails because of nil logs
+			failure: true,
+			logs:    nil,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+		{ // container step fails because of invalid container id
+			failure: true,
+			logs:    new(library.Log),
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_notfound",
+				Directory:   "/vela/src/vcs.company.com/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "notfound",
+				Number:      2,
+				Pull:        "always",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		if test.logs != nil {
+			_engine.stepLogs.Store(test.container.ID, test.logs)
+		}
+
+		_engine.steps.Store(test.container.ID, new(library.Step))
+
+		err = _engine.StreamStep(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("StreamStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("StreamStep returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_DestroyStep(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	_step := new(library.Step)
+	_step.SetName("clone")
+	_step.SetNumber(2)
+	_step.SetStatus(constants.StatusPending)
+
+	// setup tests
+	tests := []struct {
+		failure   bool
+		container *pipeline.Container
+		step      *library.Step
+	}{
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_init",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "always",
+			},
+			step: new(library.Step),
+		},
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
+			},
+			step: _step,
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_notfound",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "notfound",
+				Number:      2,
+				Pull:        "always",
+			},
+			step: new(library.Step),
+		},
+		{
+			failure: true,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_ignorenotfound",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "ignorenotfound",
+				Number:      2,
+				Pull:        "always",
+			},
+			step: new(library.Step),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		_engine.steps.Store(test.container.ID, test.step)
+
+		err = _engine.DestroyStep(context.Background(), test.container)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DestroyStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DestroyStep returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_loadStep(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		name    string
+		value   interface{}
+	}{
+		{
+			failure: false,
+			name:    "step_github_octocat_1_init",
+			value:   new(library.Step),
+		},
+		{
+			failure: true,
+			name:    "step_github_octocat_1_init",
+			value:   nil,
+		},
+		{
+			failure: true,
+			name:    "step_github_octocat_1_init",
+			value:   new(library.Log),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		if test.value != nil {
+			_engine.steps.Store(test.name, test.value)
+		}
+
+		_, err = _engine.loadStep(test.name)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("loadStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("loadStep returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_loadStepLogs(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_steps := testSteps()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		name    string
+		value   interface{}
+	}{
+		{
+			failure: false,
+			name:    "step_github_octocat_1_init",
+			value:   new(library.Log),
+		},
+		{
+			failure: true,
+			name:    "step_github_octocat_1_init",
+			value:   nil,
+		},
+		{
+			failure: true,
+			name:    "step_github_octocat_1_init",
+			value:   new(library.Step),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_steps),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		if test.value != nil {
+			_engine.stepLogs.Store(test.name, test.value)
+		}
+
+		_, err = _engine.loadStepLogs(test.name)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("loadStepLogs should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("loadStepLogs returned err: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This implements a set of functions for dealing with `steps` in the `local` executor client.

* `CreateStep()`
* `PlanStep()`
* `ExecStep()`
* `StreamStep()`
* `DestroyStep()`

This is a stepping stone to getting the `local` executor fully implemented when trying to run a pipeline locally.