### PR TITLE
feat(local): add logic for handling stages

### DIFF
--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -6,26 +6,169 @@ package local
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 )
 
 // CreateStage prepares the stage for execution.
 func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
+	// load the logs for the init step from the client
+	l, err := c.loadStepLogs(c.pipeline.Stages[0].Steps[0].ID)
+	if err != nil {
+		return err
+	}
+
+	// update the init log with progress
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+	l.AppendData([]byte(fmt.Sprintf("> Pulling step images for stage %s...\n", s.Name)))
+
+	// create the steps for the stage
+	for _, step := range s.Steps {
+		// TODO: make this not hardcoded
+		// update the init log with progress
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData([]byte(fmt.Sprintf("$ docker image inspect %s\n", step.Image)))
+
+		// create the step
+		err := c.CreateStep(ctx, step)
+		if err != nil {
+			return err
+		}
+
+		// inspect the step image
+		image, err := c.Runtime.InspectImage(ctx, step)
+		if err != nil {
+			return err
+		}
+
+		// update the init log with step image info
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
+		l.AppendData(image)
+	}
+
 	return nil
 }
 
 // PlanStage prepares the stage for execution.
 func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
+	// ensure dependent stages have completed
+	for _, needs := range s.Needs {
+		// check if a dependency stage has completed
+		stageErr, ok := m[needs]
+		if !ok { // stage not found so we continue
+			continue
+		}
+
+		// wait for the stage channel to close
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("errgroup context is done")
+		case err := <-stageErr:
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+	}
+
 	return nil
 }
 
 // ExecStage runs a stage.
 func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
+	b := c.build
+	r := c.repo
+
+	// close the stage channel at the end
+	defer close(m[s.Name])
+
+	// execute the steps for the stage
+	for _, step := range s.Steps {
+		// extract rule data from build information
+		ruledata := &pipeline.RuleData{
+			Branch: b.GetBranch(),
+			Event:  b.GetEvent(),
+			Repo:   r.GetFullName(),
+			Status: b.GetStatus(),
+		}
+
+		// when tag event add tag information into ruledata
+		if strings.EqualFold(b.GetEvent(), constants.EventTag) {
+			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
+		}
+
+		// when deployment event add deployment information into ruledata
+		if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
+			ruledata.Target = b.GetDeploy()
+		}
+
+		// check if you need to excute this step
+		if !step.Execute(ruledata) {
+			continue
+		}
+
+		// plan the step
+		err := c.PlanStep(ctx, step)
+		if err != nil {
+			return fmt.Errorf("unable to plan step %s: %w", step.Name, err)
+		}
+
+		// execute the step
+		err = c.ExecStep(ctx, step)
+		if err != nil {
+			return err
+		}
+
+		// load the step from the client
+		cStep, err := c.loadStep(step.ID)
+		if err != nil {
+			return err
+		}
+
+		// check the step exit code
+		if step.ExitCode != 0 {
+			// check if we ignore step failures
+			if !step.Ruleset.Continue {
+				// set build status to failure
+				b.SetStatus(constants.StatusFailure)
+			}
+
+			// update the step fields
+			cStep.SetExitCode(step.ExitCode)
+			cStep.SetStatus(constants.StatusFailure)
+		}
+
+		cStep.SetFinished(time.Now().UTC().Unix())
+		// send API call to update the build
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
+		_, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), cStep)
+		if err != nil {
+			return fmt.Errorf("unable to upload step state: %v", err)
+		}
+	}
+
 	return nil
 }
 
 // DestroyStage cleans up the stage after execution.
 func (c *client) DestroyStage(ctx context.Context, s *pipeline.Stage) error {
+	// destroy the steps for the stage
+	for _, step := range s.Steps {
+		// destroy the step
+		err := c.DestroyStep(ctx, step)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/executor/local/stage_test.go
+++ b/executor/local/stage_test.go
@@ -1,0 +1,489 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/go-vela/mock/server"
+
+	"github.com/go-vela/pkg-runtime/runtime/docker"
+
+	"github.com/go-vela/sdk-go/vela"
+
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestLocal_CreateStage(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_stages := testStages()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		logs    *library.Log
+		stage   *pipeline.Stage
+	}{
+		{
+			failure: false,
+			logs:    new(library.Log),
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+		{
+			failure: true,
+			logs:    nil,
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+		{
+			failure: true,
+			logs:    new(library.Log),
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:notfound",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+		{
+			failure: true,
+			logs:    new(library.Log),
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:ignorenotfound",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_stages),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		if test.logs != nil {
+			_engine.stepLogs.Store(_stages.Stages[0].Steps[0].ID, test.logs)
+		}
+
+		_engine.steps.Store(_stages.Stages[0].Steps[0].ID, new(library.Step))
+
+		err = _engine.CreateStage(context.Background(), test.stage)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateStage should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateStage returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_PlanStage(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_stages := testStages()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure  bool
+		err      error
+		stageMap map[string]chan error
+		stage    *pipeline.Stage
+	}{
+		{
+			failure:  false,
+			err:      nil,
+			stageMap: map[string]chan error{},
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+		{
+			failure: true,
+			err:     errors.New("simulated error for stage"),
+			stageMap: map[string]chan error{
+				"init": make(chan error, 1),
+			},
+			stage: &pipeline.Stage{
+				Name:  "clone",
+				Needs: []string{"init"},
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_stages),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		if len(test.stageMap) > 0 {
+			if test.err != nil {
+				test.stageMap["init"] <- test.err
+			}
+
+			close(test.stageMap["init"])
+		}
+
+		err = _engine.PlanStage(context.Background(), test.stage, test.stageMap)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("PlanStage should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("PlanStage returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_ExecStage(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_stages := testStages()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		stage   *pipeline.Stage
+	}{
+		{
+			failure: false,
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+		{
+			failure: true,
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_bad_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "clone",
+						Number:      0,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+
+		{
+			failure: true,
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_notfound",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "notfound",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		stageMap := make(map[string]chan error)
+		stageMap["init"] = make(chan error)
+		stageMap["clone"] = make(chan error)
+		stageMap["echo"] = make(chan error)
+
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_stages),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		_engine.steps.Store(_stages.Stages[0].Steps[0].ID, new(library.Step))
+		_engine.stepLogs.Store(_stages.Stages[0].Steps[0].ID, new(library.Log))
+
+		err = _engine.CreateStep(context.Background(), test.stage.Steps[0])
+		if err != nil {
+			t.Errorf("unable to create step: %v", err)
+		}
+
+		err = _engine.ExecStage(context.Background(), test.stage, stageMap)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("ExecStage should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("ExecStage returned err: %v", err)
+		}
+	}
+}
+
+func TestLocal_DestroyStage(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_repo := testRepo()
+	_user := testUser()
+	_stages := testStages()
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		stage   *pipeline.Stage
+		step    *library.Step
+	}{
+		{
+			failure: false,
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_clone",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "clone",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+			step: new(library.Step),
+		},
+		{
+			failure: true,
+			stage: &pipeline.Stage{
+				Name: "clone",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "github_octocat_1_clone_notfound",
+						Directory:   "/home/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "target/vela-git:v0.3.0",
+						Name:        "notfound",
+						Number:      2,
+						Pull:        "always",
+					},
+				},
+			},
+			step: new(library.Step),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithBuild(_build),
+			WithPipeline(_stages),
+			WithRepo(_repo),
+			WithRuntime(_runtime),
+			WithUser(_user),
+			WithVelaClient(_client),
+		)
+		if err != nil {
+			t.Errorf("unable to create executor engine: %v", err)
+		}
+
+		_engine.steps.Store(test.stage.Steps[0].ID, test.step)
+
+		err = _engine.DestroyStage(context.Background(), test.stage)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DestroyStage should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DestroyStage returned err: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This implements a set of functions for dealing with `stages` in the `local` executor client.

* `CreateStage()`
* `PlanStage()`
* `ExecStage()`
* `DestroyStage()`

This is a stepping stone to getting the `local` executor fully implemented when trying to run a pipeline locally.