### PR TITLE
feat: add internal pkg structure

### DIFF
--- a/internal/doc.go
+++ b/internal/doc.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// Package internal provides a collection of internal
+// packages used for the Vela executor systems.
+//
+// More information:
+//
+//   * https://golang.org/doc/go1.4#internalpackages
+//   * https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit
+//
+// Usage:
+//
+// 	import "github.com/go-vela/pkg-executor/internal"
+package internal

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package internal
+
+// For more information:
+//
+//   * https://golang.org/doc/go1.4#internalpackages
+//   * https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

Adding [an `internal` package that will contain common code](https://golang.org/doc/go1.4#internalpackages) for executor resources (i.e. `services`, `stages`, `steps` etc.)

Currently, we already have [a `linux` executor](https://github.com/go-vela/pkg-executor/tree/master/executor/linux) and I'm working on building [a `local` executor](https://github.com/go-vela/pkg-executor/tree/master/executor/local).

As I'm building the `local` executor, we have large chunks of code that are the same or very similar in the `linux` executor.

I'm continuing to duplicate these chunks of code in the `local` executor so I can get it functional ASAP.

But, as I find these chunks that are duplicative, I'd like to start adding them to the `internal` package (separate PRs).

Once the `local` executor is functional, I will go back and refactor both executors to use these `internal` package functions.

Ultimately, this should offer the same functionality and experience, but with less lines of code 👍 