### PR TITLE
feat(executor): add local setup

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -18,6 +18,8 @@ import (
 // Currently the following executors are supported:
 //
 // * linux
+// * local
+// nolint: godot // top level comment ends in a list
 func New(s *Setup) (Engine, error) {
 	// validate the setup being provided
 	//

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -40,6 +40,12 @@ func New(s *Setup) (Engine, error) {
 		//
 		// https://pkg.go.dev/github.com/go-vela/pkg-executor/executor?tab=doc#Setup.Linux
 		return s.Linux()
+	// TODO: use constant from go-vela/types/constants
+	case "local":
+		// handle the Local executor driver being provided
+		//
+		// https://pkg.go.dev/github.com/go-vela/pkg-executor/executor?tab=doc#Setup.Local
+		return s.Local()
 	case constants.DriverWindows:
 		// handle the Windows executor driver being provided
 		//

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-vela/mock/server"
 
 	"github.com/go-vela/pkg-executor/executor/linux"
+	"github.com/go-vela/pkg-executor/executor/local"
 
 	"github.com/go-vela/pkg-runtime/runtime/docker"
 
@@ -40,7 +41,7 @@ func TestExecutor_New(t *testing.T) {
 		t.Errorf("unable to create runtime engine: %v", err)
 	}
 
-	_engine, err := linux.New(
+	_linux, err := linux.New(
 		linux.WithBuild(_build),
 		linux.WithHostname("localhost"),
 		linux.WithPipeline(_pipeline),
@@ -51,6 +52,19 @@ func TestExecutor_New(t *testing.T) {
 	)
 	if err != nil {
 		t.Errorf("unable to create linux engine: %v", err)
+	}
+
+	_local, err := local.New(
+		local.WithBuild(_build),
+		local.WithHostname("localhost"),
+		local.WithPipeline(_pipeline),
+		local.WithRepo(_repo),
+		local.WithRuntime(_runtime),
+		local.WithUser(_user),
+		local.WithVelaClient(_client),
+	)
+	if err != nil {
+		t.Errorf("unable to create local engine: %v", err)
 	}
 
 	// setup tests
@@ -83,7 +97,20 @@ func TestExecutor_New(t *testing.T) {
 				Runtime:  _runtime,
 				User:     _user,
 			},
-			want: _engine,
+			want: _linux,
+		},
+		{
+			failure: false,
+			setup: &Setup{
+				Build:    _build,
+				Client:   _client,
+				Driver:   "local",
+				Pipeline: _pipeline,
+				Repo:     _repo,
+				Runtime:  _runtime,
+				User:     _user,
+			},
+			want: _local,
 		},
 		{
 			failure: true,

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -179,7 +179,7 @@ func TestExecutor_New(t *testing.T) {
 	}
 }
 
-// setup global variables used for testing
+// setup global variables used for testing.
 var (
 	_build = &library.Build{
 		ID:           vela.Int64(1),

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-vela/sdk-go/vela"
 
 	"github.com/go-vela/pkg-executor/executor/linux"
+	"github.com/go-vela/pkg-executor/executor/local"
 
 	"github.com/go-vela/pkg-runtime/runtime"
 
@@ -71,6 +72,25 @@ func (s *Setup) Linux() (Engine, error) {
 		linux.WithRuntime(s.Runtime),
 		linux.WithUser(s.User),
 		linux.WithVelaClient(s.Client),
+	)
+}
+
+// Local creates and returns a Vela engine capable of
+// integrating with a local executor.
+func (s *Setup) Local() (Engine, error) {
+	logrus.Trace("creating local executor client from setup")
+
+	// create new Local executor engine
+	//
+	// https://pkg.go.dev/github.com/go-vela/pkg-executor/executor/local?tab=doc#New
+	return local.New(
+		local.WithBuild(s.Build),
+		local.WithHostname(s.Hostname),
+		local.WithPipeline(s.Pipeline),
+		local.WithRepo(s.Repo),
+		local.WithRuntime(s.Runtime),
+		local.WithUser(s.User),
+		local.WithVelaClient(s.Client),
 	)
 }
 

--- a/executor/setup_test.go
+++ b/executor/setup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-vela/mock/server"
 
 	"github.com/go-vela/pkg-executor/executor/linux"
+	"github.com/go-vela/pkg-executor/executor/local"
 
 	"github.com/go-vela/pkg-runtime/runtime/docker"
 
@@ -105,6 +106,56 @@ func TestExecutor_Setup_Linux(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Linux is %v, want %v", got, want)
+	}
+}
+
+func TestExecutor_Setup_Local(t *testing.T) {
+	// setup types
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	_runtime, err := docker.NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	want, err := local.New(
+		local.WithBuild(_build),
+		local.WithHostname("localhost"),
+		local.WithPipeline(_pipeline),
+		local.WithRepo(_repo),
+		local.WithRuntime(_runtime),
+		local.WithUser(_user),
+		local.WithVelaClient(_client),
+	)
+	if err != nil {
+		t.Errorf("unable to create local engine: %v", err)
+	}
+
+	_setup := &Setup{
+		Build:    _build,
+		Client:   _client,
+		Driver:   "local",
+		Pipeline: _pipeline,
+		Repo:     _repo,
+		Runtime:  _runtime,
+		User:     _user,
+	}
+
+	// run test
+	got, err := _setup.Local()
+	if err != nil {
+		t.Errorf("Local returned err: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Local is %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This implements a `Local()` function on the `executor.Setup` type for creating the `local` executor client:

https://github.com/go-vela/pkg-executor/blob/8c81b991f1ef65c0f3ce88f693a9736c30df6c25/executor/setup.go#L78-L95

Also, added logic to handle the `local` executor driver when calling the `executor.New()` function (creates a new executor):

https://github.com/go-vela/pkg-executor/blob/8c81b991f1ef65c0f3ce88f693a9736c30df6c25/executor/executor.go#L43-L48