### PR TITLE
refactor: use os.FindProcess() for compatibility issues

### DIFF
--- a/executor/linux/api.go
+++ b/executor/linux/api.go
@@ -6,6 +6,7 @@ package linux
 
 import (
 	"fmt"
+	"os"
 	"syscall"
 
 	"github.com/go-vela/types/constants"
@@ -61,9 +62,14 @@ func (c *client) CancelBuild() (*library.Build, error) {
 	// set the build status to killed
 	b.SetStatus(constants.StatusCanceled)
 
-	err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	p, err := os.FindProcess(os.Getpid())
 	if err != nil {
-		return nil, fmt.Errorf("unable to cancel PID: %w", err)
+		return nil, fmt.Errorf("unable to find PID: %v", err)
+	}
+
+	err = p.Signal(syscall.SIGTERM)
+	if err != nil {
+		return nil, fmt.Errorf("unable to cancel PID: %v", err)
 	}
 
 	return b, nil


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

When I vendor from this repo on `master`, into the [go-vela/cli](https://github.com/go-vela/cli) repo and build the CLI with `make build`, I get the following:

```
# github.com/go-vela/pkg-executor/executor/linux
../../../../go/pkg/mod/github.com/go-vela/pkg-executor@v0.6.1-0.20201221174708-c434ad8c22a0/executor/linux/api.go:64:9: undefined: syscall.Kill
```

After doing some digging it would appear that the `syscall.Kill()` function does not exist across all OS boundaries.

By switching to using `os.FindProcess()`, this allows the CLI to build as intended.