### PR TITLE
refactor(local): ignore validating client opts

### DIFF
--- a/executor/local/local_test.go
+++ b/executor/local/local_test.go
@@ -39,25 +39,25 @@ func TestLocal_New(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
-		failure bool
-		build   *library.Build
+		failure  bool
+		pipeline *pipeline.Build
 	}{
 		{
-			failure: false,
-			build:   testBuild(),
+			failure:  false,
+			pipeline: testSteps(),
 		},
 		{
-			failure: true,
-			build:   nil,
+			failure:  true,
+			pipeline: nil,
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
 		_, err := New(
-			WithBuild(test.build),
+			WithBuild(testBuild()),
 			WithHostname("localhost"),
-			WithPipeline(testSteps()),
+			WithPipeline(test.pipeline),
 			WithRepo(testRepo()),
 			WithRuntime(_runtime),
 			WithUser(testUser()),

--- a/executor/local/opts.go
+++ b/executor/local/opts.go
@@ -21,11 +21,6 @@ type Opt func(*client) error
 // WithBuild sets the library build in the client.
 func WithBuild(b *library.Build) Opt {
 	return func(c *client) error {
-		// check if the build provided is empty
-		if b == nil {
-			return fmt.Errorf("empty build provided")
-		}
-
 		// set the build in the client
 		c.build = b
 
@@ -67,11 +62,6 @@ func WithPipeline(p *pipeline.Build) Opt {
 // WithRepo sets the library repo in the client.
 func WithRepo(r *library.Repo) Opt {
 	return func(c *client) error {
-		// check if the repo provided is empty
-		if r == nil {
-			return fmt.Errorf("empty repo provided")
-		}
-
 		// set the repo in the client
 		c.repo = r
 
@@ -97,11 +87,6 @@ func WithRuntime(r runtime.Engine) Opt {
 // WithUser sets the library user in the client.
 func WithUser(u *library.User) Opt {
 	return func(c *client) error {
-		// check if the user provided is empty
-		if u == nil {
-			return fmt.Errorf("empty user provided")
-		}
-
 		// set the user in the client
 		c.user = u
 
@@ -112,11 +97,6 @@ func WithUser(u *library.User) Opt {
 // WithVelaClient sets the Vela client in the client.
 func WithVelaClient(cli *vela.Client) Opt {
 	return func(c *client) error {
-		// check if the Vela client provided is empty
-		if cli == nil {
-			return fmt.Errorf("empty Vela client provided")
-		}
-
 		// set the Vela client in the client
 		c.Vela = cli
 

--- a/executor/local/opts_test.go
+++ b/executor/local/opts_test.go
@@ -28,16 +28,10 @@ func TestLocal_Opt_WithBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
-		failure bool
-		build   *library.Build
+		build *library.Build
 	}{
 		{
-			failure: false,
-			build:   _build,
-		},
-		{
-			failure: true,
-			build:   nil,
+			build: _build,
 		},
 	}
 
@@ -46,14 +40,6 @@ func TestLocal_Opt_WithBuild(t *testing.T) {
 		_engine, err := New(
 			WithBuild(test.build),
 		)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithBuild should have returned err")
-			}
-
-			continue
-		}
 
 		if err != nil {
 			t.Errorf("WithBuild returned err: %v", err)
@@ -145,16 +131,10 @@ func TestLocal_Opt_WithRepo(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
-		failure bool
-		repo    *library.Repo
+		repo *library.Repo
 	}{
 		{
-			failure: false,
-			repo:    _repo,
-		},
-		{
-			failure: true,
-			repo:    nil,
+			repo: _repo,
 		},
 	}
 
@@ -163,14 +143,6 @@ func TestLocal_Opt_WithRepo(t *testing.T) {
 		_engine, err := New(
 			WithRepo(test.repo),
 		)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithRepo should have returned err")
-			}
-
-			continue
-		}
 
 		if err != nil {
 			t.Errorf("WithRepo returned err: %v", err)
@@ -234,16 +206,10 @@ func TestLocal_Opt_WithUser(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
-		failure bool
-		user    *library.User
+		user *library.User
 	}{
 		{
-			failure: false,
-			user:    _user,
-		},
-		{
-			failure: true,
-			user:    nil,
+			user: _user,
 		},
 	}
 
@@ -252,14 +218,6 @@ func TestLocal_Opt_WithUser(t *testing.T) {
 		_engine, err := New(
 			WithUser(test.user),
 		)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithUser should have returned err")
-			}
-
-			continue
-		}
 
 		if err != nil {
 			t.Errorf("WithUser returned err: %v", err)
@@ -284,16 +242,10 @@ func TestLocal_Opt_WithVelaClient(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
-		failure bool
-		client  *vela.Client
+		client *vela.Client
 	}{
 		{
-			failure: false,
-			client:  _client,
-		},
-		{
-			failure: true,
-			client:  nil,
+			client: _client,
 		},
 	}
 
@@ -302,14 +254,6 @@ func TestLocal_Opt_WithVelaClient(t *testing.T) {
 		_engine, err := New(
 			WithVelaClient(test.client),
 		)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithVelaClient should have returned err")
-			}
-
-			continue
-		}
 
 		if err != nil {
 			t.Errorf("WithVelaClient returned err: %v", err)


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This is a continuation of https://github.com/go-vela/pkg-executor/pull/87

I updated the `go-vela/pkg-executor/executor` package to skip validating specific fields for the `local` executor.

However, I forgot to replicate that for `go-vela/pkg-executor/executor/local` on the client side.

I had to modify some of the tests since they previously expected to receive an error if certain fields weren't set.

They no longer will receive an error since the fields are no longer required.