### PR TITLE
refactor(local): remove API calls

### DIFF
--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -36,22 +36,13 @@ func (c *client) CreateBuild(ctx context.Context) error {
 	b.SetDistribution("linux")
 	b.SetRuntime("docker")
 
-	// send API call to update the build
-	//
-	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#BuildService.Update
-	b, _, err := c.Vela.Build.Update(r.GetOrg(), r.GetName(), b)
-	if err != nil {
-		e = err
-		return fmt.Errorf("unable to upload build state: %v", err)
-	}
-
 	c.build = b
 
 	// load the init container from the pipeline
 	init := c.loadInitContainer(p)
 
 	// create the step
-	err = c.CreateStep(ctx, init)
+	err := c.CreateStep(ctx, init)
 	if err != nil {
 		e = err
 		return fmt.Errorf("unable to create %s step: %w", init.Name, err)
@@ -97,23 +88,6 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 	defer func() {
 		s.SetFinished(time.Now().UTC().Unix())
-		// send API call to update the step
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err := c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
-		if err != nil {
-			// TODO: Should this be changed or removed?
-			fmt.Println(err)
-		}
-
-		// send API call to update the logs for the step
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-		l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), init.Number, l)
-		if err != nil {
-			// TODO: Should this be changed or removed?
-			fmt.Println(err)
-		}
 	}()
 
 	// create the runtime network for the pipeline
@@ -196,23 +170,6 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 	defer func() {
 		sInit.SetFinished(time.Now().UTC().Unix())
-		// send API call to update the step
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err := c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), sInit)
-		if err != nil {
-			// TODO: Should this be changed or removed?
-			fmt.Println(err)
-		}
-
-		// send API call to update the logs for the step
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-		l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), init.Number, l)
-		if err != nil {
-			// TODO: Should this be changed or removed?
-			fmt.Println(err)
-		}
 	}()
 
 	// update the init log with progress
@@ -339,15 +296,6 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		}
 		// update the build fields
 		b.SetFinished(time.Now().UTC().Unix())
-
-		// send API call to update the build
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#BuildService.Update
-		_, _, err := c.Vela.Build.Update(r.GetOrg(), r.GetName(), b)
-		if err != nil {
-			// TODO: Should this be changed or removed?
-			fmt.Println(err)
-		}
 	}()
 
 	// execute the services for the pipeline
@@ -431,14 +379,6 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		}
 
 		cStep.SetFinished(time.Now().UTC().Unix())
-		// send API call to update the build
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), cStep)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to upload step state: %v", err)
-		}
 	}
 
 	// create an error group with the context for each stage

--- a/executor/local/build_test.go
+++ b/executor/local/build_test.go
@@ -62,11 +62,6 @@ func TestLocal_CreateBuild(t *testing.T) {
 			build:    _build,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		{ // pipeline with empty build
-			failure:  true,
-			build:    new(library.Build),
-			pipeline: "testdata/build/steps/basic.yml",
-		},
 	}
 
 	// run test

--- a/executor/local/service_test.go
+++ b/executor/local/service_test.go
@@ -145,19 +145,6 @@ func TestLocal_PlanService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{
-			failure: true,
-			container: &pipeline.Container{
-				ID:          "service_github_octocat_1_postgres",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "postgres:12-alpine",
-				Name:        "postgres",
-				Number:      0,
-				Ports:       []string{"5432:5432"},
-				Pull:        "not_present",
-			},
-		},
 	}
 
 	// run tests

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -148,13 +148,6 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 		}
 
 		cStep.SetFinished(time.Now().UTC().Unix())
-		// send API call to update the build
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), cStep)
-		if err != nil {
-			return fmt.Errorf("unable to upload step state: %v", err)
-		}
 	}
 
 	return nil

--- a/executor/local/stage_test.go
+++ b/executor/local/stage_test.go
@@ -317,24 +317,6 @@ func TestLocal_ExecStage(t *testing.T) {
 				Name: "clone",
 				Steps: pipeline.ContainerSlice{
 					{
-						ID:          "github_octocat_1_bad_clone_clone",
-						Directory:   "/home/github/octocat",
-						Environment: map[string]string{"FOO": "bar"},
-						Image:       "target/vela-git:v0.3.0",
-						Name:        "clone",
-						Number:      0,
-						Pull:        "always",
-					},
-				},
-			},
-		},
-
-		{
-			failure: true,
-			stage: &pipeline.Stage{
-				Name: "clone",
-				Steps: pipeline.ContainerSlice{
-					{
 						ID:          "github_octocat_1_clone_notfound",
 						Directory:   "/home/github/octocat",
 						Environment: map[string]string{"FOO": "bar"},

--- a/executor/local/step_test.go
+++ b/executor/local/step_test.go
@@ -154,18 +154,6 @@ func TestLocal_PlanStep(t *testing.T) {
 				Pull:        "always",
 			},
 		},
-		{
-			failure: true,
-			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "clone",
-				Number:      0,
-				Pull:        "always",
-			},
-		},
 	}
 
 	// run tests


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This removes any calls to the Vela API from the `local` executor.

Currently, running a pipeline on a local workstation and uploading results to the Vela API is considered out of scope.