### PR TITLE
refactor(local): output all logs to stdout

### DIFF
--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -7,6 +7,7 @@ package local
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/go-vela/pkg-executor/internal/build"
 	"github.com/go-vela/pkg-executor/internal/step"
 	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/pipeline"
 )
 
 // CreateBuild configures the build for execution.
@@ -80,11 +80,8 @@ func (c *client) PlanBuild(ctx context.Context) error {
 		return err
 	}
 
-	// load the logs for the init step from the client
-	l, err := step.LoadLogs(init, &c.stepLogs)
-	if err != nil {
-		return err
-	}
+	// create a step pattern for log output
+	_pattern := fmt.Sprintf(stepPattern, init.Name)
 
 	defer func() {
 		s.SetFinished(time.Now().UTC().Unix())
@@ -97,10 +94,11 @@ func (c *client) PlanBuild(ctx context.Context) error {
 		return fmt.Errorf("unable to create network: %w", err)
 	}
 
-	// update the init log with progress
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte("> Inspecting runtime network...\n"))
+	// output init progress to stdout
+	fmt.Fprintln(os.Stdout, _pattern, "> Inspecting runtime network...")
+
+	// output the network command to stdout
+	fmt.Fprintln(os.Stdout, _pattern, "$ docker network inspect", p.ID)
 
 	// inspect the runtime network for the pipeline
 	network, err := c.Runtime.InspectNetwork(ctx, p)
@@ -109,11 +107,8 @@ func (c *client) PlanBuild(ctx context.Context) error {
 		return fmt.Errorf("unable to inspect network: %w", err)
 	}
 
-	// update the init log with network command
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte(fmt.Sprintf("$ docker network inspect %s \n", p.ID)))
-	l.AppendData(network)
+	// output the network information to stdout
+	fmt.Fprintln(os.Stdout, _pattern, string(network))
 
 	// create the runtime volume for the pipeline
 	err = c.Runtime.CreateVolume(ctx, p)
@@ -122,10 +117,11 @@ func (c *client) PlanBuild(ctx context.Context) error {
 		return fmt.Errorf("unable to create volume: %w", err)
 	}
 
-	// update the init log with progress
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte("> Inspecting runtime volume...\n"))
+	// output init progress to stdout
+	fmt.Fprintln(os.Stdout, _pattern, "> Inspecting runtime volume...")
+
+	// output the volume command to stdout
+	fmt.Fprintln(os.Stdout, _pattern, "$ docker volume inspect", p.ID)
 
 	// inspect the runtime volume for the pipeline
 	volume, err := c.Runtime.InspectVolume(ctx, p)
@@ -134,11 +130,8 @@ func (c *client) PlanBuild(ctx context.Context) error {
 		return fmt.Errorf("unable to inspect volume: %w", err)
 	}
 
-	// update the init log with volume command
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte(fmt.Sprintf("$ docker volume inspect %s \n", p.ID)))
-	l.AppendData(volume)
+	// output the volume information to stdout
+	fmt.Fprintln(os.Stdout, _pattern, string(volume))
 
 	return nil
 }
@@ -162,31 +155,20 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		return err
 	}
 
-	// load the logs for the init step from the client
-	l, err := step.LoadLogs(init, &c.stepLogs)
-	if err != nil {
-		return err
-	}
+	// create a step pattern for log output
+	_pattern := fmt.Sprintf(stepPattern, init.Name)
 
 	defer func() {
 		sInit.SetFinished(time.Now().UTC().Unix())
 	}()
 
-	// update the init log with progress
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte("> Pulling service images...\n"))
+	// output init progress to stdout
+	fmt.Fprintln(os.Stdout, _pattern, "> Pulling service images...")
 
 	// create the services for the pipeline
 	for _, s := range p.Services {
 		// TODO: remove this; but we need it for tests
 		s.Detach = true
-
-		// TODO: remove hardcoded reference
-		// update the init log with progress
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-		l.AppendData([]byte(fmt.Sprintf("$ docker image inspect %s\n", s.Image)))
 
 		// create the service
 		err := c.CreateService(ctx, s)
@@ -195,6 +177,9 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 			return fmt.Errorf("unable to create %s service: %w", s.Name, err)
 		}
 
+		// output the image command to stdout
+		fmt.Fprintln(os.Stdout, _pattern, "$ docker image inspect", s.Image)
+
 		// inspect the service image
 		image, err := c.Runtime.InspectImage(ctx, s)
 		if err != nil {
@@ -202,16 +187,12 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 			return fmt.Errorf("unable to inspect %s service: %w", s.Name, err)
 		}
 
-		// update the init log with service image info
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-		l.AppendData(image)
+		// output the image information to stdout
+		fmt.Fprintln(os.Stdout, _pattern, string(image))
 	}
 
-	// update the init log with progress
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte("> Pulling stage images...\n"))
+	// output init progress to stdout
+	fmt.Fprintln(os.Stdout, _pattern, "> Pulling stage images...")
 
 	// create the stages for the pipeline
 	for _, s := range p.Stages {
@@ -228,10 +209,8 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		}
 	}
 
-	// update the init log with progress
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte("> Pulling step images...\n"))
+	// output init progress to stdout
+	fmt.Fprintln(os.Stdout, _pattern, "> Pulling step images...")
 
 	// create the steps for the pipeline
 	for _, s := range p.Steps {
@@ -240,17 +219,15 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 			continue
 		}
 
-		// update the init log with progress
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-		l.AppendData([]byte(fmt.Sprintf("$ docker image inspect %s\n", s.Image)))
-
 		// create the step
 		err := c.CreateStep(ctx, s)
 		if err != nil {
 			e = err
 			return fmt.Errorf("unable to create %s step: %w", s.Name, err)
 		}
+
+		// output the image command to stdout
+		fmt.Fprintln(os.Stdout, _pattern, "$ docker image inspect", s.Image)
 
 		// inspect the step image
 		image, err := c.Runtime.InspectImage(ctx, s)
@@ -259,11 +236,12 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 			return fmt.Errorf("unable to inspect %s step: %w", s.Name, err)
 		}
 
-		// update the init log with step image info
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-		l.AppendData(image)
+		// output the image information to stdout
+		fmt.Fprintln(os.Stdout, _pattern, string(image))
 	}
+
+	// output a new line for readability to stdout
+	fmt.Fprintln(os.Stdout, "")
 
 	return nil
 }
@@ -274,7 +252,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 func (c *client) ExecBuild(ctx context.Context) error {
 	b := c.build
 	p := c.pipeline
-	r := c.repo
+	// r := c.repo
 	e := c.err
 
 	defer func() {
@@ -322,28 +300,28 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			continue
 		}
 
-		// extract rule data from build information
-		ruledata := &pipeline.RuleData{
-			Branch: b.GetBranch(),
-			Event:  b.GetEvent(),
-			Repo:   r.GetFullName(),
-			Status: b.GetStatus(),
-		}
+		// // extract rule data from build information
+		// ruledata := &pipeline.RuleData{
+		// 	Branch: b.GetBranch(),
+		// 	Event:  b.GetEvent(),
+		// 	Repo:   r.GetFullName(),
+		// 	Status: b.GetStatus(),
+		// }
 
-		// when tag event add tag information into ruledata
-		if strings.EqualFold(b.GetEvent(), constants.EventTag) {
-			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
-		}
+		// // when tag event add tag information into ruledata
+		// if strings.EqualFold(b.GetEvent(), constants.EventTag) {
+		// 	ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
+		// }
 
-		// when deployment event add deployment information into ruledata
-		if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
-			ruledata.Target = b.GetDeploy()
-		}
+		// // when deployment event add deployment information into ruledata
+		// if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
+		// 	ruledata.Target = b.GetDeploy()
+		// }
 
-		// check if you need to excute this step
-		if !s.Execute(ruledata) {
-			continue
-		}
+		// // check if you need to excute this step
+		// if !s.Execute(ruledata) {
+		// 	continue
+		// }
 
 		// plan the step
 		err := c.PlanStep(ctx, s)

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-vela/pkg-executor/internal/build"
 	"github.com/go-vela/pkg-executor/internal/step"
 	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/pipeline"
 )
 
 // CreateBuild configures the build for execution.
@@ -252,7 +253,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 func (c *client) ExecBuild(ctx context.Context) error {
 	b := c.build
 	p := c.pipeline
-	// r := c.repo
+	r := c.repo
 	e := c.err
 
 	defer func() {
@@ -300,28 +301,28 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			continue
 		}
 
-		// // extract rule data from build information
-		// ruledata := &pipeline.RuleData{
-		// 	Branch: b.GetBranch(),
-		// 	Event:  b.GetEvent(),
-		// 	Repo:   r.GetFullName(),
-		// 	Status: b.GetStatus(),
-		// }
+		// extract rule data from build information
+		ruledata := &pipeline.RuleData{
+			Branch: b.GetBranch(),
+			Event:  b.GetEvent(),
+			Repo:   r.GetFullName(),
+			Status: b.GetStatus(),
+		}
 
-		// // when tag event add tag information into ruledata
-		// if strings.EqualFold(b.GetEvent(), constants.EventTag) {
-		// 	ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
-		// }
+		// when tag event add tag information into ruledata
+		if strings.EqualFold(b.GetEvent(), constants.EventTag) {
+			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
+		}
 
-		// // when deployment event add deployment information into ruledata
-		// if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
-		// 	ruledata.Target = b.GetDeploy()
-		// }
+		// when deployment event add deployment information into ruledata
+		if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
+			ruledata.Target = b.GetDeploy()
+		}
 
-		// // check if you need to excute this step
-		// if !s.Execute(ruledata) {
-		// 	continue
-		// }
+		// check if you need to excute this step
+		if !s.Execute(ruledata) {
+			continue
+		}
 
 		// plan the step
 		err := c.PlanStep(ctx, s)

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -18,6 +18,9 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
+// create a service logging pattern.
+const servicePattern = "[service: %s]"
+
 // CreateService configures the service for execution.
 func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) error {
 	ctn.Environment["BUILD_HOST"] = c.Hostname
@@ -101,13 +104,16 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 	}
 	defer rc.Close()
 
+	// create a service pattern for log output
+	_pattern := fmt.Sprintf(servicePattern, ctn.Name)
+
 	// create new scanner from the container output
 	scanner := bufio.NewScanner(rc)
 
 	// scan entire container output
 	for scanner.Scan() {
 		// ensure we output to stdout
-		fmt.Fprintln(os.Stdout, scanner.Text())
+		fmt.Fprintln(os.Stdout, _pattern, scanner.Text())
 	}
 
 	return scanner.Err()

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-vela/pkg-executor/internal/step"
@@ -76,35 +77,35 @@ func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m map[string]
 // ExecStage runs a stage.
 func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
 	b := c.build
-	// r := c.repo
+	r := c.repo
 
 	// close the stage channel at the end
 	defer close(m[s.Name])
 
 	// execute the steps for the stage
 	for _, _step := range s.Steps {
-		// // extract rule data from build information
-		// ruledata := &pipeline.RuleData{
-		// 	Branch: b.GetBranch(),
-		// 	Event:  b.GetEvent(),
-		// 	Repo:   r.GetFullName(),
-		// 	Status: b.GetStatus(),
-		// }
+		// extract rule data from build information
+		ruledata := &pipeline.RuleData{
+			Branch: b.GetBranch(),
+			Event:  b.GetEvent(),
+			Repo:   r.GetFullName(),
+			Status: b.GetStatus(),
+		}
 
-		// // when tag event add tag information into ruledata
-		// if strings.EqualFold(b.GetEvent(), constants.EventTag) {
-		// 	ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
-		// }
+		// when tag event add tag information into ruledata
+		if strings.EqualFold(b.GetEvent(), constants.EventTag) {
+			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
+		}
 
-		// // when deployment event add deployment information into ruledata
-		// if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
-		// 	ruledata.Target = b.GetDeploy()
-		// }
+		// when deployment event add deployment information into ruledata
+		if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
+			ruledata.Target = b.GetDeploy()
+		}
 
-		// // check if you need to excute this step
-		// if !_step.Execute(ruledata) {
-		// 	continue
-		// }
+		// check if you need to excute this step
+		if !_step.Execute(ruledata) {
+			continue
+		}
 
 		// plan the step
 		err := c.PlanStep(ctx, _step)

--- a/executor/local/stage_test.go
+++ b/executor/local/stage_test.go
@@ -69,24 +69,6 @@ func TestLocal_CreateStage(t *testing.T) {
 		},
 		{
 			failure: true,
-			logs:    nil,
-			stage: &pipeline.Stage{
-				Name: "clone",
-				Steps: pipeline.ContainerSlice{
-					{
-						ID:          "github_octocat_1_clone_clone",
-						Directory:   "/home/github/octocat",
-						Environment: map[string]string{"FOO": "bar"},
-						Image:       "target/vela-git:v0.3.0",
-						Name:        "clone",
-						Number:      2,
-						Pull:        "always",
-					},
-				},
-			},
-		},
-		{
-			failure: true,
 			logs:    new(library.Log),
 			stage: &pipeline.Stage{
 				Name: "clone",
@@ -142,6 +124,12 @@ func TestLocal_CreateStage(t *testing.T) {
 		}
 
 		_engine.steps.Store(_stages.Stages[0].Steps[0].ID, new(library.Step))
+
+		// run create for init process to be created properly
+		err = _engine.CreateBuild(context.Background())
+		if err != nil {
+			t.Errorf("unable to create build: %v", err)
+		}
 
 		err = _engine.CreateStage(context.Background(), test.stage)
 

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -17,6 +17,9 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
+// create a step logging pattern.
+const stepPattern = "[step: %s]"
+
 // CreateStep configures the step for execution.
 func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error {
 	ctn.Environment["BUILD_HOST"] = c.Hostname
@@ -132,13 +135,16 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 	}
 	defer rc.Close()
 
+	// create a step pattern for log output
+	_pattern := fmt.Sprintf(stepPattern, ctn.Name)
+
 	// create new scanner from the container output
 	scanner := bufio.NewScanner(rc)
 
 	// scan entire container output
 	for scanner.Scan() {
 		// ensure we output to stdout
-		fmt.Fprintln(os.Stdout, scanner.Text())
+		fmt.Fprintln(os.Stdout, _pattern, scanner.Text())
 	}
 
 	return scanner.Err()


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This updates the `local` executor to output all logs to `stdout` via `fmt.Fprintln(os.Stdout, <message>)`.

Accompanying this, each line of output should have a key setup to indicate what the log is for.

Currently the key patterns are:

* `[service: <service_name>]`
* `[step: <step_name>]`

Here is a sample from the `init` logs I'm running locally:

```
[step: init] > Inspecting runtime network...
[step: init] $ docker network inspect localOrg_localRepo_1
[step: init] {
 "Name": "localOrg_localRepo_1",
 "Id": "a39d29402f469d828ccaa7de602fe62aaddea5a011379fc38da224cb07aac981",
 "Created": "2021-01-13T14:36:49.9474592Z",
 "Scope": "local",
 "Driver": "bridge",
 "EnableIPv6": false,
 "IPAM": {
  "Driver": "default",
  "Options": null,
  "Config": [
   {
    "Subnet": "172.31.0.0/16",
    "Gateway": "172.31.0.1"
   }
  ]
 },
 "Internal": false,
 "Attachable": false,
 "Ingress": false,
 "ConfigFrom": {
  "Network": ""
 },
 "ConfigOnly": false,
 "Containers": {},
 "Options": {},
 "Labels": {}
}

[step: init] > Inspecting runtime volume...
[step: init] $ docker volume inspect localOrg_localRepo_1
[step: init] {
 "CreatedAt": "2021-01-13T14:36:49Z",
 "Driver": "local",
 "Labels": null,
 "Mountpoint": "/var/lib/docker/volumes/localOrg_localRepo_1/_data",
 "Name": "localOrg_localRepo_1",
 "Options": null,
 "Scope": "local"
}
```