### PR TITLE
refactor(local): update variable configuration

### DIFF
--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -51,8 +51,6 @@ func (c *client) CreateBuild(ctx context.Context) error {
 }
 
 // PlanBuild prepares the build for execution.
-//
-// nolint: funlen // ignore function length - will be refactored at a later date
 func (c *client) PlanBuild(ctx context.Context) error {
 	// defer taking snapshot of build
 	defer build.Snapshot(c.build, nil, c.err, nil, nil)
@@ -109,8 +107,6 @@ func (c *client) PlanBuild(ctx context.Context) error {
 }
 
 // AssembleBuild prepares the containers within a build for execution.
-//
-// nolint: funlen // ignore function length - will be refactored at a later date
 func (c *client) AssembleBuild(ctx context.Context) error {
 	// defer taking snapshot of build
 	defer build.Snapshot(c.build, nil, c.err, nil, nil)

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -48,26 +48,26 @@ func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) err
 // PlanService prepares the service for execution.
 func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error {
 	// update the engine service object
-	s := new(library.Service)
-	s.SetName(ctn.Name)
-	s.SetNumber(ctn.Number)
-	s.SetStatus(constants.StatusRunning)
-	s.SetStarted(time.Now().UTC().Unix())
-	s.SetHost(ctn.Environment["VELA_HOST"])
-	s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-	s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+	_service := new(library.Service)
+	_service.SetName(ctn.Name)
+	_service.SetNumber(ctn.Number)
+	_service.SetStatus(constants.StatusRunning)
+	_service.SetStarted(time.Now().UTC().Unix())
+	_service.SetHost(ctn.Environment["VELA_HOST"])
+	_service.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+	_service.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
 
 	// add a service to a map
-	c.services.Store(ctn.ID, s)
+	c.services.Store(ctn.ID, _service)
 
 	// update the engine service log object
-	l := new(library.Log)
-	l.SetBuildID(c.build.GetID())
-	l.SetRepoID(c.repo.GetID())
-	l.SetServiceID(s.GetID())
+	_log := new(library.Log)
+	_log.SetBuildID(c.build.GetID())
+	_log.SetRepoID(c.repo.GetID())
+	_log.SetServiceID(_service.GetID())
 
 	// add a service log to a map
-	c.serviceLogs.Store(ctn.ID, l)
+	c.serviceLogs.Store(ctn.ID, _log)
 
 	return nil
 }
@@ -118,33 +118,33 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 // DestroyService cleans up services after execution.
 func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) error {
 	// load the service from the client
-	s, err := service.Load(ctn, &c.services)
+	_service, err := service.Load(ctn, &c.services)
 	if err != nil {
 		// create the service from the container
-		s = new(library.Service)
-		s.SetName(ctn.Name)
-		s.SetNumber(ctn.Number)
-		s.SetStatus(constants.StatusPending)
-		s.SetHost(ctn.Environment["VELA_HOST"])
-		s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-		s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+		_service = new(library.Service)
+		_service.SetName(ctn.Name)
+		_service.SetNumber(ctn.Number)
+		_service.SetStatus(constants.StatusPending)
+		_service.SetHost(ctn.Environment["VELA_HOST"])
+		_service.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+		_service.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
 	}
 
 	// check if the service is in a pending state
-	if s.GetStatus() == constants.StatusPending {
+	if _service.GetStatus() == constants.StatusPending {
 		// update the service fields
 		//
 		// TODO: consider making this a constant
 		//
 		// nolint: gomnd // ignore magic number 137
-		s.SetExitCode(137)
-		s.SetFinished(time.Now().UTC().Unix())
-		s.SetStatus(constants.StatusKilled)
+		_service.SetExitCode(137)
+		_service.SetFinished(time.Now().UTC().Unix())
+		_service.SetStatus(constants.StatusKilled)
 
 		// check if the service was not started
-		if s.GetStarted() == 0 {
+		if _service.GetStarted() == 0 {
 			// set the started time to the finished time
-			s.SetStarted(s.GetFinished())
+			_service.SetStarted(_service.GetFinished())
 		}
 	}
 
@@ -155,16 +155,16 @@ func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) er
 	}
 
 	// check if the service finished
-	if s.GetFinished() == 0 {
+	if _service.GetFinished() == 0 {
 		// update the service fields
-		s.SetFinished(time.Now().UTC().Unix())
-		s.SetStatus(constants.StatusSuccess)
+		_service.SetFinished(time.Now().UTC().Unix())
+		_service.SetStatus(constants.StatusSuccess)
 
 		// check the container for an unsuccessful exit code
 		if ctn.ExitCode > 0 {
 			// update the service fields
-			s.SetExitCode(ctn.ExitCode)
-			s.SetStatus(constants.StatusFailure)
+			_service.SetExitCode(ctn.ExitCode)
+			_service.SetStatus(constants.StatusFailure)
 		}
 	}
 

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -47,9 +47,6 @@ func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) err
 
 // PlanService prepares the service for execution.
 func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error {
-	b := c.build
-	r := c.repo
-
 	// update the engine service object
 	s := new(library.Service)
 	s.SetName(ctn.Name)
@@ -65,8 +62,8 @@ func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error
 
 	// update the engine service log object
 	l := new(library.Log)
-	l.SetBuildID(b.GetID())
-	l.SetRepoID(r.GetID())
+	l.SetBuildID(c.build.GetID())
+	l.SetRepoID(c.repo.GetID())
 	l.SetServiceID(s.GetID())
 
 	// add a service log to a map
@@ -87,8 +84,7 @@ func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error
 		// stream logs from container
 		err := c.StreamService(ctx, ctn)
 		if err != nil {
-			// TODO: Should this be changed or removed?
-			fmt.Println(err)
+			fmt.Fprintln(os.Stdout, "unable to stream logs for service:", err)
 		}
 	}()
 

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -76,9 +76,6 @@ func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m map[string]
 
 // ExecStage runs a stage.
 func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
-	b := c.build
-	r := c.repo
-
 	// close the stage channel at the end
 	defer close(m[s.Name])
 
@@ -86,20 +83,20 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 	for _, _step := range s.Steps {
 		// extract rule data from build information
 		ruledata := &pipeline.RuleData{
-			Branch: b.GetBranch(),
-			Event:  b.GetEvent(),
-			Repo:   r.GetFullName(),
-			Status: b.GetStatus(),
+			Branch: c.build.GetBranch(),
+			Event:  c.build.GetEvent(),
+			Repo:   c.repo.GetFullName(),
+			Status: c.build.GetStatus(),
 		}
 
 		// when tag event add tag information into ruledata
-		if strings.EqualFold(b.GetEvent(), constants.EventTag) {
+		if strings.EqualFold(c.build.GetEvent(), constants.EventTag) {
 			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
 		}
 
 		// when deployment event add deployment information into ruledata
-		if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
-			ruledata.Target = b.GetDeploy()
+		if strings.EqualFold(c.build.GetEvent(), constants.EventDeploy) {
+			ruledata.Target = c.build.GetDeploy()
 		}
 
 		// check if you need to excute this step
@@ -116,7 +113,7 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 		// execute the step
 		err = c.ExecStep(ctx, _step)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to exec step %s: %w", _step.Name, err)
 		}
 
 		// load the step from the client
@@ -130,7 +127,7 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 			// check if we ignore step failures
 			if !_step.Ruleset.Continue {
 				// set build status to failure
-				b.SetStatus(constants.StatusFailure)
+				c.build.SetStatus(constants.StatusFailure)
 			}
 
 			// update the step fields

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -25,18 +25,18 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 	fmt.Fprintln(os.Stdout, _pattern, "> Pulling step images for stage", s.Name, "...")
 
 	// create the steps for the stage
-	for _, step := range s.Steps {
+	for _, _step := range s.Steps {
 		// create the step
-		err := c.CreateStep(ctx, step)
+		err := c.CreateStep(ctx, _step)
 		if err != nil {
 			return err
 		}
 
 		// output image command to stdout
-		fmt.Fprintln(os.Stdout, _pattern, "$ docker image inspect", step.Image)
+		fmt.Fprintln(os.Stdout, _pattern, "$ docker image inspect", _step.Image)
 
 		// inspect the step image
-		image, err := c.Runtime.InspectImage(ctx, step)
+		image, err := c.Runtime.InspectImage(ctx, _step)
 		if err != nil {
 			return err
 		}
@@ -144,9 +144,9 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 // DestroyStage cleans up the stage after execution.
 func (c *client) DestroyStage(ctx context.Context, s *pipeline.Stage) error {
 	// destroy the steps for the stage
-	for _, step := range s.Steps {
+	for _, _step := range s.Steps {
 		// destroy the step
-		err := c.DestroyStep(ctx, step)
+		err := c.DestroyStep(ctx, _step)
 		if err != nil {
 			return err
 		}

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -52,26 +52,26 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 // PlanStep prepares the step for execution.
 func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	// update the engine step object
-	s := new(library.Step)
-	s.SetName(ctn.Name)
-	s.SetNumber(ctn.Number)
-	s.SetStatus(constants.StatusRunning)
-	s.SetStarted(time.Now().UTC().Unix())
-	s.SetHost(ctn.Environment["VELA_HOST"])
-	s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-	s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+	_step := new(library.Step)
+	_step.SetName(ctn.Name)
+	_step.SetNumber(ctn.Number)
+	_step.SetStatus(constants.StatusRunning)
+	_step.SetStarted(time.Now().UTC().Unix())
+	_step.SetHost(ctn.Environment["VELA_HOST"])
+	_step.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+	_step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
 
 	// add a step to a map
-	c.steps.Store(ctn.ID, s)
+	c.steps.Store(ctn.ID, _step)
 
 	// update the engine step log object
-	l := new(library.Log)
-	l.SetBuildID(c.build.GetID())
-	l.SetRepoID(c.repo.GetID())
-	l.SetStepID(s.GetID())
+	_log := new(library.Log)
+	_log.SetBuildID(c.build.GetID())
+	_log.SetRepoID(c.repo.GetID())
+	_log.SetStepID(_step.GetID())
 
 	// add a step log to a map
-	c.stepLogs.Store(ctn.ID, l)
+	c.stepLogs.Store(ctn.ID, _log)
 
 	return nil
 }
@@ -155,33 +155,33 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 	}
 
 	// load the step from the client
-	s, err := step.Load(ctn, &c.steps)
+	_step, err := step.Load(ctn, &c.steps)
 	if err != nil {
 		// create the step from the container
-		s = new(library.Step)
-		s.SetName(ctn.Name)
-		s.SetNumber(ctn.Number)
-		s.SetStatus(constants.StatusPending)
-		s.SetHost(ctn.Environment["VELA_HOST"])
-		s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-		s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+		_step = new(library.Step)
+		_step.SetName(ctn.Name)
+		_step.SetNumber(ctn.Number)
+		_step.SetStatus(constants.StatusPending)
+		_step.SetHost(ctn.Environment["VELA_HOST"])
+		_step.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+		_step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
 	}
 
 	// check if the step is in a pending state
-	if s.GetStatus() == constants.StatusPending {
+	if _step.GetStatus() == constants.StatusPending {
 		// update the step fields
 		//
 		// TODO: consider making this a constant
 		//
 		// nolint: gomnd // ignore magic number 137
-		s.SetExitCode(137)
-		s.SetFinished(time.Now().UTC().Unix())
-		s.SetStatus(constants.StatusKilled)
+		_step.SetExitCode(137)
+		_step.SetFinished(time.Now().UTC().Unix())
+		_step.SetStatus(constants.StatusKilled)
 
 		// check if the step was not started
-		if s.GetStarted() == 0 {
+		if _step.GetStarted() == 0 {
 			// set the started time to the finished time
-			s.SetStarted(s.GetFinished())
+			_step.SetStarted(_step.GetFinished())
 		}
 	}
 
@@ -192,16 +192,16 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 	}
 
 	// check if the step finished
-	if s.GetFinished() == 0 {
+	if _step.GetFinished() == 0 {
 		// update the step fields
-		s.SetFinished(time.Now().UTC().Unix())
-		s.SetStatus(constants.StatusSuccess)
+		_step.SetFinished(time.Now().UTC().Unix())
+		_step.SetStatus(constants.StatusSuccess)
 
 		// check the container for an unsuccessful exit code
 		if ctn.ExitCode > 0 {
 			// update the step fields
-			s.SetExitCode(ctn.ExitCode)
-			s.SetStatus(constants.StatusFailure)
+			_step.SetExitCode(ctn.ExitCode)
+			_step.SetStatus(constants.StatusFailure)
 		}
 	}
 

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -51,9 +51,6 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 
 // PlanStep prepares the step for execution.
 func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
-	b := c.build
-	r := c.repo
-
 	// update the engine step object
 	s := new(library.Step)
 	s.SetName(ctn.Name)
@@ -69,8 +66,8 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 
 	// update the engine step log object
 	l := new(library.Log)
-	l.SetBuildID(b.GetID())
-	l.SetRepoID(r.GetID())
+	l.SetBuildID(c.build.GetID())
+	l.SetRepoID(c.repo.GetID())
 	l.SetStepID(s.GetID())
 
 	// add a step log to a map


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

## Part 1

Removing the "shorthand" variable declarations in the `local` executor.

Throughout the codebase, the first logic of each function is creating short variable declarations:

https://github.com/go-vela/pkg-executor/blob/a5e4076bc95d388ea3d884f7217866c937bc30d3/executor/local/build.go#L24-L27

The problem with this (beyond the extra LOC and variables), is then we are left to update the client with that short variable:

https://github.com/go-vela/pkg-executor/blob/a5e4076bc95d388ea3d884f7217866c937bc30d3/executor/local/build.go#L40

This attempts to make the variable stored in the client the "source of truth" so to speak since we always reference that.

## Part 2

Introducing a consistent `_<resource>` pattern for the `local` executor variables in the code:

* `_service`
* `_stage`
* `_step`
