### PR TITLE
enhancement(internal): add empty container check

### DIFF
--- a/internal/service/load.go
+++ b/internal/service/load.go
@@ -15,6 +15,11 @@ import (
 // Load attempts to capture the library service
 // representing the container from the map.
 func Load(c *pipeline.Container, m *sync.Map) (*library.Service, error) {
+	// check if the container provided is empty
+	if c == nil {
+		return nil, fmt.Errorf("empty container provided")
+	}
+
 	// load the container ID as the service key from the map
 	result, ok := m.Load(c.ID)
 	if !ok {
@@ -33,6 +38,11 @@ func Load(c *pipeline.Container, m *sync.Map) (*library.Service, error) {
 // LoadLogs attempts to capture the library service logs
 // representing the container from the map.
 func LoadLogs(c *pipeline.Container, m *sync.Map) (*library.Log, error) {
+	// check if the container provided is empty
+	if c == nil {
+		return nil, fmt.Errorf("empty container provided")
+	}
+
 	// load the container ID as the service log key from the map
 	result, ok := m.Load(c.ID)
 	if !ok {

--- a/internal/service/load_test.go
+++ b/internal/service/load_test.go
@@ -57,6 +57,12 @@ func TestService_Load(t *testing.T) {
 			want:      nil,
 			_map:      new(sync.Map),
 		},
+		{
+			failure:   true,
+			container: nil,
+			want:      nil,
+			_map:      nil,
+		},
 	}
 
 	// run tests
@@ -124,6 +130,12 @@ func TestStep_LoadLogs(t *testing.T) {
 			container: new(pipeline.Container),
 			want:      nil,
 			_map:      new(sync.Map),
+		},
+		{
+			failure:   true,
+			container: nil,
+			want:      nil,
+			_map:      nil,
 		},
 	}
 

--- a/internal/step/load.go
+++ b/internal/step/load.go
@@ -15,6 +15,11 @@ import (
 // Load attempts to capture the library step
 // representing the container from the map.
 func Load(c *pipeline.Container, m *sync.Map) (*library.Step, error) {
+	// check if the container provided is empty
+	if c == nil {
+		return nil, fmt.Errorf("empty container provided")
+	}
+
 	// load the container ID as the step key from the map
 	result, ok := m.Load(c.ID)
 	if !ok {
@@ -33,6 +38,11 @@ func Load(c *pipeline.Container, m *sync.Map) (*library.Step, error) {
 // LoadLogs attempts to capture the library step logs
 // representing the container from the map.
 func LoadLogs(c *pipeline.Container, m *sync.Map) (*library.Log, error) {
+	// check if the container provided is empty
+	if c == nil {
+		return nil, fmt.Errorf("empty container provided")
+	}
+
 	// load the container ID as the step log key from the map
 	result, ok := m.Load(c.ID)
 	if !ok {

--- a/internal/step/load_test.go
+++ b/internal/step/load_test.go
@@ -56,6 +56,12 @@ func TestStep_Load(t *testing.T) {
 			want:      nil,
 			_map:      new(sync.Map),
 		},
+		{
+			failure:   true,
+			container: nil,
+			want:      nil,
+			_map:      nil,
+		},
 	}
 
 	// run tests
@@ -122,6 +128,12 @@ func TestStep_LoadLogs(t *testing.T) {
 			container: new(pipeline.Container),
 			want:      nil,
 			_map:      new(sync.Map),
+		},
+		{
+			failure:   true,
+			container: nil,
+			want:      nil,
+			_map:      nil,
 		},
 	}
 


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds a check to the `Load()` and `LoadLogs()` functions.

This is important, because we make references to the fields inside the container so if it is `nil`, we get panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14a00e6]

goroutine 574 [running]:
testing.tRunner.func1.1(0x22dd460, 0x30c00b0)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc00057ad80)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1075 +0x41a
panic(0x22dd460, 0x30c00b0)
	/usr/local/Cellar/go/1.15.6/libexec/src/runtime/panic.go:969 +0x1b9
github.com/go-vela/pkg-executor/internal/step.LoadLogs(0x0, 0xc0002d6240, 0x0, 0xc0008c9b30, 0x2275b40)
	.../github.com/go-vela/pkg-executor/internal/step/load.go:37 +0x26
github.com/go-vela/pkg-executor/executor/linux.(*client).CreateStage(0xc0002d6140, 0x26eb460, 0xc0000460f8, 0xc0006c5e80, 0x0, 0x0)
	.../github.com/go-vela/pkg-executor/executor/linux/stage.go:21 +0x53
github.com/go-vela/pkg-executor/executor/linux.TestLinux_CreateStage(0xc00057ad80)
	.../github.com/go-vela/pkg-executor/executor/linux/stage_test.go:147 +0xe29
testing.tRunner(0xc00057ad80, 0x2574d30)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1168 +0x2b3
```

### Services

https://github.com/go-vela/pkg-executor/blob/74c52fab5cbc3478cb4f7ef5420edac0a366c513/internal/service/load.go#L15-L21

https://github.com/go-vela/pkg-executor/blob/74c52fab5cbc3478cb4f7ef5420edac0a366c513/internal/service/load.go#L38-L44

### Steps

https://github.com/go-vela/pkg-executor/blob/74c52fab5cbc3478cb4f7ef5420edac0a366c513/internal/step/load.go#L15-L21

https://github.com/go-vela/pkg-executor/blob/74c52fab5cbc3478cb4f7ef5420edac0a366c513/internal/step/load.go#L38-L44

