### PR TITLE
refactor(linux): update variable configuration

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -21,109 +21,89 @@ import (
 
 // CreateBuild configures the build for execution.
 func (c *client) CreateBuild(ctx context.Context) error {
-	b := c.build
-	p := c.pipeline
-	r := c.repo
-	e := c.err
-
 	// defer taking snapshot of build
-	defer build.Snapshot(b, c.Vela, e, c.logger, r)
+	defer build.Snapshot(c.build, c.Vela, c.err, c.logger, c.repo)
 
 	// update the build fields
-	b.SetStatus(constants.StatusRunning)
-	b.SetStarted(time.Now().UTC().Unix())
-	b.SetHost(c.Hostname)
+	c.build.SetStatus(constants.StatusRunning)
+	c.build.SetStarted(time.Now().UTC().Unix())
+	c.build.SetHost(c.Hostname)
 	// TODO: This should not be hardcoded
-	b.SetDistribution("linux")
-	b.SetRuntime("docker")
+	c.build.SetDistribution("linux")
+	c.build.SetRuntime("docker")
 
 	c.logger.Info("uploading build state")
 	// send API call to update the build
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#BuildService.Update
-	b, _, err := c.Vela.Build.Update(r.GetOrg(), r.GetName(), b)
-	if err != nil {
-		e = err
-		return fmt.Errorf("unable to upload build state: %v", err)
+	c.build, _, c.err = c.Vela.Build.Update(c.repo.GetOrg(), c.repo.GetName(), c.build)
+	if c.err != nil {
+		return fmt.Errorf("unable to upload build state: %v", c.err)
 	}
-
-	c.build = b
 
 	// load the init container from the pipeline
-	init := c.loadInitContainer(p)
+	c.init = c.loadInitContainer(c.pipeline)
 
-	c.logger.Infof("creating %s step", init.Name)
+	c.logger.Infof("creating %s step", c.init.Name)
 	// create the step
-	err = c.CreateStep(ctx, init)
-	if err != nil {
-		e = err
-		return fmt.Errorf("unable to create %s step: %w", init.Name, err)
+	c.err = c.CreateStep(ctx, c.init)
+	if c.err != nil {
+		return fmt.Errorf("unable to create %s step: %w", c.init.Name, c.err)
 	}
 
-	c.logger.Infof("planning %s step", init.Name)
+	c.logger.Infof("planning %s step", c.init.Name)
 	// plan the step
-	err = c.PlanStep(ctx, init)
-	if err != nil {
-		e = err
-		return fmt.Errorf("unable to plan %s step: %w", init.Name, err)
+	c.err = c.PlanStep(ctx, c.init)
+	if c.err != nil {
+		return fmt.Errorf("unable to plan %s step: %w", c.init.Name, c.err)
 	}
 
-	// add the init container to secrets client
-	c.init = init
-
-	return nil
+	return c.err
 }
 
 // PlanBuild prepares the build for execution.
 func (c *client) PlanBuild(ctx context.Context) error {
-	b := c.build
-	p := c.pipeline
-	r := c.repo
-	e := c.err
-	init := c.init
-
 	// defer taking snapshot of build
-	defer build.Snapshot(b, c.Vela, e, c.logger, r)
+	defer build.Snapshot(c.build, c.Vela, c.err, c.logger, c.repo)
 
 	// load the init step from the client
-	s, err := step.Load(init, &c.steps)
+	s, err := step.Load(c.init, &c.steps)
 	if err != nil {
 		return err
 	}
 
 	// load the logs for the init step from the client
-	l, err := step.LoadLogs(init, &c.stepLogs)
+	l, err := step.LoadLogs(c.init, &c.stepLogs)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
 		s.SetFinished(time.Now().UTC().Unix())
-		c.logger.Infof("uploading %s step state", init.Name)
+		c.logger.Infof("uploading %s step state", c.init.Name)
 		// send API call to update the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err := c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+		_, _, err := c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), s)
 		if err != nil {
-			c.logger.Errorf("unable to upload %s state: %v", init.Name, err)
+			c.logger.Errorf("unable to upload %s state: %v", c.init.Name, err)
 		}
 
-		c.logger.Infof("uploading %s step logs", init.Name)
+		c.logger.Infof("uploading %s step logs", c.init.Name)
 		// send API call to update the logs for the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-		l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), init.Number, l)
+		l, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), c.init.Number, l)
 		if err != nil {
-			c.logger.Errorf("unable to upload %s logs: %v", init.Name, err)
+			c.logger.Errorf("unable to upload %s logs: %v", c.init.Name, err)
 		}
 	}()
 
 	c.logger.Info("creating network")
 	// create the runtime network for the pipeline
-	err = c.Runtime.CreateNetwork(ctx, p)
-	if err != nil {
-		e = err
-		return fmt.Errorf("unable to create network: %w", err)
+	c.err = c.Runtime.CreateNetwork(ctx, c.pipeline)
+	if c.err != nil {
+		return fmt.Errorf("unable to create network: %w", c.err)
 	}
 
 	// update the init log with progress
@@ -132,24 +112,23 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	l.AppendData([]byte("> Inspecting runtime network...\n"))
 
 	// inspect the runtime network for the pipeline
-	network, err := c.Runtime.InspectNetwork(ctx, p)
+	network, err := c.Runtime.InspectNetwork(ctx, c.pipeline)
 	if err != nil {
-		e = err
+		c.err = err
 		return fmt.Errorf("unable to inspect network: %w", err)
 	}
 
 	// update the init log with network command
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte(fmt.Sprintf("$ docker network inspect %s \n", p.ID)))
+	l.AppendData([]byte(fmt.Sprintf("$ docker network inspect %s \n", c.pipeline.ID)))
 	l.AppendData(network)
 
 	c.logger.Info("creating volume")
 	// create the runtime volume for the pipeline
-	err = c.Runtime.CreateVolume(ctx, p)
-	if err != nil {
-		e = err
-		return fmt.Errorf("unable to create volume: %w", err)
+	c.err = c.Runtime.CreateVolume(ctx, c.pipeline)
+	if c.err != nil {
+		return fmt.Errorf("unable to create volume: %w", c.err)
 	}
 
 	// update the init log with progress
@@ -158,16 +137,16 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	l.AppendData([]byte("> Inspecting runtime volume...\n"))
 
 	// inspect the runtime volume for the pipeline
-	volume, err := c.Runtime.InspectVolume(ctx, p)
+	volume, err := c.Runtime.InspectVolume(ctx, c.pipeline)
 	if err != nil {
-		e = err
+		c.err = err
 		return fmt.Errorf("unable to inspect volume: %w", err)
 	}
 
 	// update the init log with volume command
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte(fmt.Sprintf("$ docker volume inspect %s \n", p.ID)))
+	l.AppendData([]byte(fmt.Sprintf("$ docker volume inspect %s \n", c.pipeline.ID)))
 	l.AppendData(volume)
 
 	// update the init log with progress
@@ -176,7 +155,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	l.AppendData([]byte("> Pulling secrets...\n"))
 
 	// iterate through each secret provided in the pipeline
-	for _, secret := range p.Secrets {
+	for _, secret := range c.pipeline.Secrets {
 		// ignore pulling secrets coming from plugins
 		if !secret.Origin.Empty() {
 			continue
@@ -186,7 +165,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 		s, err := c.secret.pull(secret)
 		if err != nil {
-			e = err
+			c.err = err
 			return fmt.Errorf("unable to pull secrets: %w", err)
 		}
 
@@ -196,7 +175,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 		sRaw, err := json.MarshalIndent(s.Sanitize(), "", " ")
 		if err != nil {
-			e = err
+			c.err = err
 			return fmt.Errorf("unable to decode secret: %w", err)
 		}
 
@@ -211,45 +190,39 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 // AssembleBuild prepares the containers within a build for execution.
 func (c *client) AssembleBuild(ctx context.Context) error {
-	b := c.build
-	p := c.pipeline
-	r := c.repo
-	e := c.err
-	init := c.init
-
 	// defer taking snapshot of build
-	defer build.Snapshot(b, c.Vela, e, c.logger, r)
+	defer build.Snapshot(c.build, c.Vela, c.err, c.logger, c.repo)
 
 	// load the init step from the client
-	sInit, err := step.Load(init, &c.steps)
+	sInit, err := step.Load(c.init, &c.steps)
 	if err != nil {
 		return err
 	}
 
 	// load the logs for the init step from the client
-	l, err := step.LoadLogs(init, &c.stepLogs)
+	l, err := step.LoadLogs(c.init, &c.stepLogs)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
 		sInit.SetFinished(time.Now().UTC().Unix())
-		c.logger.Infof("uploading %s step state", init.Name)
+		c.logger.Infof("uploading %s step state", c.init.Name)
 		// send API call to update the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err := c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), sInit)
+		_, _, err := c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), sInit)
 		if err != nil {
-			c.logger.Errorf("unable to upload %s state: %v", init.Name, err)
+			c.logger.Errorf("unable to upload %s state: %v", c.init.Name, err)
 		}
 
-		c.logger.Infof("uploading %s step logs", init.Name)
+		c.logger.Infof("uploading %s step logs", c.init.Name)
 		// send API call to update the logs for the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-		l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), init.Number, l)
+		l, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), c.init.Number, l)
 		if err != nil {
-			c.logger.Errorf("unable to upload %s logs: %v", init.Name, err)
+			c.logger.Errorf("unable to upload %s logs: %v", c.init.Name, err)
 		}
 	}()
 
@@ -259,7 +232,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	l.AppendData([]byte("> Pulling service images...\n"))
 
 	// create the services for the pipeline
-	for _, s := range p.Services {
+	for _, s := range c.pipeline.Services {
 		// TODO: remove this; but we need it for tests
 		s.Detach = true
 
@@ -271,17 +244,16 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		c.logger.Infof("creating %s service", s.Name)
 		// create the service
-		err := c.CreateService(ctx, s)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to create %s service: %w", s.Name, err)
+		c.err = c.CreateService(ctx, s)
+		if c.err != nil {
+			return fmt.Errorf("unable to create %s service: %w", s.Name, c.err)
 		}
 
 		c.logger.Infof("inspecting %s service", s.Name)
 		// inspect the service image
 		image, err := c.Runtime.InspectImage(ctx, s)
 		if err != nil {
-			e = err
+			c.err = err
 			return fmt.Errorf("unable to inspect %s service: %w", s.Name, err)
 		}
 
@@ -297,7 +269,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	l.AppendData([]byte("> Pulling stage images...\n"))
 
 	// create the stages for the pipeline
-	for _, s := range p.Stages {
+	for _, s := range c.pipeline.Stages {
 		// TODO: remove hardcoded reference
 		if s.Name == "init" {
 			continue
@@ -305,10 +277,9 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		c.logger.Infof("creating %s stage", s.Name)
 		// create the stage
-		err := c.CreateStage(ctx, s)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to create %s stage: %w", s.Name, err)
+		c.err = c.CreateStage(ctx, s)
+		if c.err != nil {
+			return fmt.Errorf("unable to create %s stage: %w", s.Name, c.err)
 		}
 	}
 
@@ -318,7 +289,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	l.AppendData([]byte("> Pulling step images...\n"))
 
 	// create the steps for the pipeline
-	for _, s := range p.Steps {
+	for _, s := range c.pipeline.Steps {
 		// TODO: remove hardcoded reference
 		if s.Name == "init" {
 			continue
@@ -331,18 +302,17 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		c.logger.Infof("creating %s step", s.Name)
 		// create the step
-		err := c.CreateStep(ctx, s)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to create %s step: %w", s.Name, err)
+		c.err = c.CreateStep(ctx, s)
+		if c.err != nil {
+			return fmt.Errorf("unable to create %s step: %w", s.Name, c.err)
 		}
 
 		c.logger.Infof("inspecting %s step", s.Name)
 		// inspect the step image
 		image, err := c.Runtime.InspectImage(ctx, s)
 		if err != nil {
-			e = err
-			return fmt.Errorf("unable to inspect %s step: %w", s.Name, err)
+			c.err = err
+			return fmt.Errorf("unable to inspect %s step: %w", s.Name, c.err)
 		}
 
 		// update the init log with step image info
@@ -357,7 +327,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	l.AppendData([]byte("> Pulling secret images...\n"))
 
 	// create the secrets for the pipeline
-	for _, s := range p.Secrets {
+	for _, s := range c.pipeline.Secrets {
 		// skip over non-plugin secrets
 		if s.Origin.Empty() {
 			continue
@@ -370,17 +340,16 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		c.logger.Infof("creating %s secret", s.Origin.Name)
 		// create the service
-		err := c.secret.create(ctx, s.Origin)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to create %s secret: %w", s.Origin.Name, err)
+		c.err = c.secret.create(ctx, s.Origin)
+		if c.err != nil {
+			return fmt.Errorf("unable to create %s secret: %w", s.Origin.Name, c.err)
 		}
 
 		c.logger.Infof("inspecting %s secret", s.Origin.Name)
 		// inspect the service image
 		image, err := c.Runtime.InspectImage(ctx, s.Origin)
 		if err != nil {
-			e = err
+			c.err = err
 			return fmt.Errorf("unable to inspect %s secret: %w", s.Origin.Name, err)
 		}
 
@@ -397,73 +366,65 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 	c.logger.Info("executing secret images")
 	// execute the secret
-	err = c.secret.exec(ctx, &p.Secrets)
-	if err != nil {
-		e = err
-		return fmt.Errorf("unable to execute secret: %w", err)
+	c.err = c.secret.exec(ctx, &c.pipeline.Secrets)
+	if c.err != nil {
+		return fmt.Errorf("unable to execute secret: %w", c.err)
 	}
 
-	return nil
+	return c.err
 }
 
 // ExecBuild runs a pipeline for a build.
 func (c *client) ExecBuild(ctx context.Context) error {
-	b := c.build
-	p := c.pipeline
-	r := c.repo
-	e := c.err
-
 	defer func() {
 		// Overwrite with proper status and error only if build was not canceled
-		if !strings.EqualFold(b.GetStatus(), constants.StatusCanceled) {
+		if !strings.EqualFold(c.build.GetStatus(), constants.StatusCanceled) {
 			// NOTE: if the build is already in a failure state we do not
 			// want to update the state to be success
-			if !strings.EqualFold(b.GetStatus(), constants.StatusFailure) {
-				b.SetStatus(constants.StatusSuccess)
+			if !strings.EqualFold(c.build.GetStatus(), constants.StatusFailure) {
+				c.build.SetStatus(constants.StatusSuccess)
 			}
 
 			// NOTE: When an error occurs during a build that does not have to do
 			// with a pipeline we should set build status to "error" not "failed"
 			// because it is worker related and not build.
-			if e != nil {
-				b.SetError(e.Error())
-				b.SetStatus(constants.StatusError)
+			if c.err != nil {
+				c.build.SetError(c.err.Error())
+				c.build.SetStatus(constants.StatusError)
 			}
 		}
 		// update the build fields
-		b.SetFinished(time.Now().UTC().Unix())
+		c.build.SetFinished(time.Now().UTC().Unix())
 
 		c.logger.Info("uploading build state")
 		// send API call to update the build
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#BuildService.Update
-		_, _, err := c.Vela.Build.Update(r.GetOrg(), r.GetName(), b)
+		_, _, err := c.Vela.Build.Update(c.repo.GetOrg(), c.repo.GetName(), c.build)
 		if err != nil {
 			c.logger.Errorf("unable to upload build state: %v", err)
 		}
 	}()
 
 	// execute the services for the pipeline
-	for _, s := range p.Services {
+	for _, s := range c.pipeline.Services {
 		c.logger.Infof("planning %s service", s.Name)
 		// plan the service
-		err := c.PlanService(ctx, s)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to plan service: %w", err)
+		c.err = c.PlanService(ctx, s)
+		if c.err != nil {
+			return fmt.Errorf("unable to plan service: %w", c.err)
 		}
 
 		c.logger.Infof("executing %s service", s.Name)
 		// execute the service
-		err = c.ExecService(ctx, s)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to execute service: %w", err)
+		c.err = c.ExecService(ctx, s)
+		if c.err != nil {
+			return fmt.Errorf("unable to execute service: %w", c.err)
 		}
 	}
 
 	// execute the steps for the pipeline
-	for _, s := range p.Steps {
+	for _, s := range c.pipeline.Steps {
 		// TODO: remove hardcoded reference
 		if s.Name == "init" {
 			continue
@@ -471,20 +432,20 @@ func (c *client) ExecBuild(ctx context.Context) error {
 
 		// extract rule data from build information
 		ruledata := &pipeline.RuleData{
-			Branch: b.GetBranch(),
-			Event:  b.GetEvent(),
-			Repo:   r.GetFullName(),
-			Status: b.GetStatus(),
+			Branch: c.build.GetBranch(),
+			Event:  c.build.GetEvent(),
+			Repo:   c.repo.GetFullName(),
+			Status: c.build.GetStatus(),
 		}
 
 		// when tag event add tag information into ruledata
-		if strings.EqualFold(b.GetEvent(), constants.EventTag) {
+		if strings.EqualFold(c.build.GetEvent(), constants.EventTag) {
 			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
 		}
 
 		// when deployment event add deployment information into ruledata
-		if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
-			ruledata.Target = b.GetDeploy()
+		if strings.EqualFold(c.build.GetEvent(), constants.EventDeploy) {
+			ruledata.Target = c.build.GetDeploy()
 		}
 
 		// check if you need to excute this step
@@ -494,18 +455,16 @@ func (c *client) ExecBuild(ctx context.Context) error {
 
 		c.logger.Infof("planning %s step", s.Name)
 		// plan the step
-		err := c.PlanStep(ctx, s)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to plan step: %w", err)
+		c.err = c.PlanStep(ctx, s)
+		if c.err != nil {
+			return fmt.Errorf("unable to plan step: %w", c.err)
 		}
 
 		c.logger.Infof("executing %s step", s.Name)
 		// execute the step
-		err = c.ExecStep(ctx, s)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to execute step: %w", err)
+		c.err = c.ExecStep(ctx, s)
+		if c.err != nil {
+			return fmt.Errorf("unable to execute step: %w", c.err)
 		}
 
 		// load the step from the client
@@ -519,7 +478,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			// check if we ignore step failures
 			if !s.Ruleset.Continue {
 				// set build status to failure
-				b.SetStatus(constants.StatusFailure)
+				c.build.SetStatus(constants.StatusFailure)
 			}
 
 			// update the step fields
@@ -532,10 +491,9 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		// send API call to update the build
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), cStep)
-		if err != nil {
-			e = err
-			return fmt.Errorf("unable to upload step state: %v", err)
+		_, _, c.err = c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), cStep)
+		if c.err != nil {
+			return fmt.Errorf("unable to upload step state: %v", c.err)
 		}
 	}
 
@@ -547,7 +505,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	stageMap := make(map[string]chan error)
 
 	// iterate through each stage in the pipeline
-	for _, s := range p.Stages {
+	for _, s := range c.pipeline.Stages {
 		// TODO: remove hardcoded reference
 		if s.Name == "init" {
 			continue
@@ -565,18 +523,16 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		stages.Go(func() error {
 			c.logger.Infof("planning %s stage", stage.Name)
 			// plan the stage
-			err := c.PlanStage(stageCtx, stage, stageMap)
-			if err != nil {
-				e = err
-				return fmt.Errorf("unable to plan stage: %w", err)
+			c.err = c.PlanStage(stageCtx, stage, stageMap)
+			if c.err != nil {
+				return fmt.Errorf("unable to plan stage: %w", c.err)
 			}
 
 			c.logger.Infof("executing %s stage", stage.Name)
 			// execute the stage
-			err = c.ExecStage(stageCtx, stage, stageMap)
-			if err != nil {
-				e = err
-				return fmt.Errorf("unable to execute stage: %w", err)
+			c.err = c.ExecStage(stageCtx, stage, stageMap)
+			if c.err != nil {
+				return fmt.Errorf("unable to execute stage: %w", c.err)
 			}
 
 			return nil
@@ -587,13 +543,12 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	// wait for the stages to complete or return an error
 	//
 	// https://pkg.go.dev/golang.org/x/sync/errgroup?tab=doc#Group.Wait
-	err := stages.Wait()
-	if err != nil {
-		e = err
-		return fmt.Errorf("unable to wait for stages: %v", err)
+	c.err = stages.Wait()
+	if c.err != nil {
+		return fmt.Errorf("unable to wait for stages: %v", c.err)
 	}
 
-	return nil
+	return c.err
 }
 
 // DestroyBuild cleans up the build after execution.

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -62,6 +62,8 @@ func (c *client) CreateBuild(ctx context.Context) error {
 }
 
 // PlanBuild prepares the build for execution.
+//
+// nolint: funlen // ignore function length due to comments and logging messages
 func (c *client) PlanBuild(ctx context.Context) error {
 	// defer taking snapshot of build
 	defer build.Snapshot(c.build, c.Vela, c.err, c.logger, c.repo)

--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -248,6 +248,7 @@ func (s *secretSvc) exec(ctx context.Context, p *pipeline.SecretSlice) error {
 
 // pull defines a function that pulls the secrets from the server for a given pipeline.
 func (s *secretSvc) pull(secret *pipeline.Secret) (*library.Secret, error) {
+	// nolint: staticheck // reports the value is never used but we return it
 	_secret := new(library.Secret)
 
 	switch secret.Type {
@@ -375,6 +376,7 @@ func (s *secretSvc) stream(ctx context.Context, ctn *pipeline.Container) error {
 			// send API call to append the logs for the init step
 			//
 			// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
+			// nolint: lll // skip line length due to variable names
 			_log, _, err = s.client.Vela.Log.UpdateStep(s.client.repo.GetOrg(), s.client.repo.GetName(), s.client.build.GetNumber(), s.client.init.Number, _log)
 			if err != nil {
 				return err
@@ -388,8 +390,9 @@ func (s *secretSvc) stream(ctx context.Context, ctn *pipeline.Container) error {
 	return scanner.Err()
 }
 
-// helper function to check secret whitelist before setting value
 // TODO: Evaluate pulling this into a "bool" types function for injecting
+//
+// helper function to check secret whitelist before setting value.
 func injectSecrets(ctn *pipeline.Container, m map[string]*library.Secret) error {
 	// inject secrets for step
 	for _, _secret := range ctn.Secrets {

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -78,21 +78,6 @@ func TestLinux_Secret_create(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{
-			failure: true,
-			container: &pipeline.Container{
-				ID:        "secret_github_octocat_1_vault",
-				Directory: "/vela/src/vcs.company.com/github/octocat",
-				Environment: map[string]string{
-					"BAR": "1\n2\n",
-					"FOO": "!@#$%^&*()\\",
-				},
-				Image:  "target/secret-vault:latest",
-				Name:   "vault",
-				Number: 1,
-				Pull:   "not_present",
-			},
-		},
 	}
 
 	// run tests

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -60,9 +60,6 @@ func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) err
 func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error {
 	var err error
 
-	b := c.build
-	r := c.repo
-
 	// update engine logger with service metadata
 	//
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithField
@@ -82,7 +79,7 @@ func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error
 	// send API call to update the service
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#SvcService.Update
-	s, _, err = c.Vela.Svc.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+	s, _, err = c.Vela.Svc.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), s)
 	if err != nil {
 		return err
 	}
@@ -97,7 +94,7 @@ func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error
 	// send API call to capture the service log
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.GetService
-	l, _, err := c.Vela.Log.GetService(r.GetOrg(), r.GetName(), b.GetNumber(), s.GetNumber())
+	l, _, err := c.Vela.Log.GetService(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), s.GetNumber())
 	if err != nil {
 		return err
 	}
@@ -136,9 +133,6 @@ func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error
 
 // StreamService tails the output for a service.
 func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) error {
-	b := c.build
-	r := c.repo
-
 	// update engine logger with service metadata
 	//
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithField
@@ -180,7 +174,7 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 		// send API call to update the logs for the service
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
-		_, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+		_, _, err = c.Vela.Log.UpdateService(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, l)
 		if err != nil {
 			logger.Errorf("unable to upload container logs: %v", err)
 		}
@@ -215,7 +209,7 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 			// send API call to append the logs for the service
 			//
 			// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
-			l, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+			l, _, err = c.Vela.Log.UpdateService(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, l)
 			if err != nil {
 				return err
 			}

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -18,7 +18,7 @@ import (
 // CreateStage prepares the stage for execution.
 func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 	// load the logs for the init step from the client
-	l, err := step.LoadLogs(c.init, &c.stepLogs)
+	_log, err := step.LoadLogs(c.init, &c.stepLogs)
 	if err != nil {
 		return err
 	}
@@ -31,26 +31,26 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 	// update the init log with progress
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	l.AppendData([]byte(fmt.Sprintf("> Pulling step images for stage %s...\n", s.Name)))
+	_log.AppendData([]byte(fmt.Sprintf("> Pulling step images for stage %s...\n", s.Name)))
 
 	// create the steps for the stage
-	for _, step := range s.Steps {
+	for _, _step := range s.Steps {
 		// TODO: make this not hardcoded
 		// update the init log with progress
 		//
 		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-		l.AppendData([]byte(fmt.Sprintf("$ docker image inspect %s\n", step.Image)))
+		_log.AppendData([]byte(fmt.Sprintf("$ docker image inspect %s\n", _step.Image)))
 
-		logger.Debugf("creating %s step", step.Name)
+		logger.Debugf("creating %s step", _step.Name)
 		// create the step
-		err := c.CreateStep(ctx, step)
+		err := c.CreateStep(ctx, _step)
 		if err != nil {
 			return err
 		}
 
-		logger.Infof("inspecting image for %s step", step.Name)
+		logger.Infof("inspecting image for %s step", _step.Name)
 		// inspect the step image
-		image, err := c.Runtime.InspectImage(ctx, step)
+		image, err := c.Runtime.InspectImage(ctx, _step)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 		// update the init log with step image info
 		//
 		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-		l.AppendData(image)
+		_log.AppendData(image)
 	}
 
 	return nil
@@ -190,10 +190,10 @@ func (c *client) DestroyStage(ctx context.Context, s *pipeline.Stage) error {
 	logger := c.logger.WithField("stage", s.Name)
 
 	// destroy the steps for the stage
-	for _, step := range s.Steps {
-		logger.Debugf("destroying %s step", step.Name)
+	for _, _step := range s.Steps {
+		logger.Debugf("destroying %s step", _step.Name)
 		// destroy the step
-		err := c.DestroyStep(ctx, step)
+		err := c.DestroyStep(ctx, _step)
 		if err != nil {
 			return err
 		}

--- a/executor/linux/stage_test.go
+++ b/executor/linux/stage_test.go
@@ -138,10 +138,9 @@ func TestLinux_CreateStage(t *testing.T) {
 		}
 
 		if test.logs != nil {
-			_engine.stepLogs.Store(_stages.Stages[0].Steps[0].ID, test.logs)
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
 		}
-
-		_engine.steps.Store(_stages.Stages[0].Steps[0].ID, new(library.Step))
 
 		err = _engine.CreateStage(context.Background(), test.stage)
 

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -65,9 +65,6 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	var err error
 
-	b := c.build
-	r := c.repo
-
 	// update engine logger with step metadata
 	//
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithField
@@ -87,7 +84,7 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	// send API call to update the step
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-	s, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+	s, _, err = c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), s)
 	if err != nil {
 		return err
 	}
@@ -102,7 +99,7 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	// send API call to capture the step log
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.GetStep
-	l, _, err := c.Vela.Log.GetStep(r.GetOrg(), r.GetName(), b.GetNumber(), s.GetNumber())
+	l, _, err := c.Vela.Log.GetStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), s.GetNumber())
 	if err != nil {
 		return err
 	}
@@ -170,9 +167,6 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 		return nil
 	}
 
-	b := c.build
-	r := c.repo
-
 	// update engine logger with step metadata
 	//
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithField
@@ -214,7 +208,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 		// send API call to update the logs for the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-		_, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+		_, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, l)
 		if err != nil {
 			logger.Errorf("unable to upload container logs: %v", err)
 		}
@@ -249,7 +243,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 			// send API call to append the logs for the step
 			//
 			// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-			l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+			l, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, l)
 			if err != nil {
 				return err
 			}

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -71,41 +71,41 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	logger := c.logger.WithField("step", ctn.Name)
 
 	// update the engine step object
-	s := new(library.Step)
-	s.SetName(ctn.Name)
-	s.SetNumber(ctn.Number)
-	s.SetStatus(constants.StatusRunning)
-	s.SetStarted(time.Now().UTC().Unix())
-	s.SetHost(ctn.Environment["VELA_HOST"])
-	s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-	s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+	_step := new(library.Step)
+	_step.SetName(ctn.Name)
+	_step.SetNumber(ctn.Number)
+	_step.SetStatus(constants.StatusRunning)
+	_step.SetStarted(time.Now().UTC().Unix())
+	_step.SetHost(ctn.Environment["VELA_HOST"])
+	_step.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+	_step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
 
 	logger.Debug("uploading step state")
 	// send API call to update the step
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-	s, _, err = c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), s)
+	_step, _, err = c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), _step)
 	if err != nil {
 		return err
 	}
 
-	s.SetStatus(constants.StatusSuccess)
+	_step.SetStatus(constants.StatusSuccess)
 
 	// add a step to a map
-	c.steps.Store(ctn.ID, s)
+	c.steps.Store(ctn.ID, _step)
 
 	// get the step log here
 	logger.Debug("retrieve step log")
 	// send API call to capture the step log
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.GetStep
-	l, _, err := c.Vela.Log.GetStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), s.GetNumber())
+	_log, _, err := c.Vela.Log.GetStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), _step.GetNumber())
 	if err != nil {
 		return err
 	}
 
 	// add a step log to a map
-	c.stepLogs.Store(ctn.ID, l)
+	c.stepLogs.Store(ctn.ID, _log)
 
 	return nil
 }
@@ -173,7 +173,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 	logger := c.logger.WithField("step", ctn.Name)
 
 	// load the logs for the step from the client
-	l, err := step.LoadLogs(ctn, &c.stepLogs)
+	_log, err := step.LoadLogs(ctn, &c.stepLogs)
 	if err != nil {
 		return err
 	}
@@ -202,13 +202,13 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 		// overwrite the existing log with all bytes
 		//
 		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.SetData
-		l.SetData(data)
+		_log.SetData(data)
 
 		logger.Debug("uploading logs")
 		// send API call to update the logs for the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-		_, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, l)
+		_, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
 		if err != nil {
 			logger.Errorf("unable to upload container logs: %v", err)
 		}
@@ -237,13 +237,13 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 			// update the existing log with the new bytes
 			//
 			// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-			l.AppendData(logs.Bytes())
+			_log.AppendData(logs.Bytes())
 
 			logger.Debug("appending logs")
 			// send API call to append the logs for the step
 			//
 			// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-			l, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, l)
+			_log, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
 			if err != nil {
 				return err
 			}
@@ -269,16 +269,16 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 	logger := c.logger.WithField("step", ctn.Name)
 
 	// load the step from the client
-	s, err := step.Load(ctn, &c.steps)
+	_step, err := step.Load(ctn, &c.steps)
 	if err != nil {
 		// create the step from the container
-		s = new(library.Step)
-		s.SetName(ctn.Name)
-		s.SetNumber(ctn.Number)
-		s.SetStatus(constants.StatusPending)
-		s.SetHost(ctn.Environment["VELA_HOST"])
-		s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-		s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+		_step = new(library.Step)
+		_step.SetName(ctn.Name)
+		_step.SetNumber(ctn.Number)
+		_step.SetStatus(constants.StatusPending)
+		_step.SetHost(ctn.Environment["VELA_HOST"])
+		_step.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+		_step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
 	}
 
 	defer func() {
@@ -286,27 +286,27 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 		// send API call to update the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err := c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), s)
+		_, _, err := c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), _step)
 		if err != nil {
 			logger.Errorf("unable to upload step snapshot: %v", err)
 		}
 	}()
 
 	// check if the step is in a pending state
-	if s.GetStatus() == constants.StatusPending {
+	if _step.GetStatus() == constants.StatusPending {
 		// update the step fields
 		//
 		// TODO: consider making this a constant
 		//
 		// nolint: gomnd // ignore magic number 137
-		s.SetExitCode(137)
-		s.SetFinished(time.Now().UTC().Unix())
-		s.SetStatus(constants.StatusKilled)
+		_step.SetExitCode(137)
+		_step.SetFinished(time.Now().UTC().Unix())
+		_step.SetStatus(constants.StatusKilled)
 
 		// check if the step was not started
-		if s.GetStarted() == 0 {
+		if _step.GetStarted() == 0 {
 			// set the started time to the finished time
-			s.SetStarted(s.GetFinished())
+			_step.SetStarted(_step.GetFinished())
 		}
 	}
 
@@ -318,16 +318,16 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 	}
 
 	// check if the step finished
-	if s.GetFinished() == 0 {
+	if _step.GetFinished() == 0 {
 		// update the step fields
-		s.SetFinished(time.Now().UTC().Unix())
-		s.SetStatus(constants.StatusSuccess)
+		_step.SetFinished(time.Now().UTC().Unix())
+		_step.SetStatus(constants.StatusSuccess)
 
 		// check the container for an unsuccessful exit code
 		if ctn.ExitCode > 0 {
 			// update the step fields
-			s.SetExitCode(ctn.ExitCode)
-			s.SetStatus(constants.StatusFailure)
+			_step.SetExitCode(ctn.ExitCode)
+			_step.SetStatus(constants.StatusFailure)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/go-vela/pkg-executor
 go 1.15
 
 require (
-	github.com/drone/envsubst v1.0.2
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-vela/compiler v0.7.0-rc1
 	github.com/go-vela/mock v0.7.0-rc1


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

Dependent on https://github.com/go-vela/pkg-executor/pull/95

## Part 1

Removing the "shorthand" variable declarations in the `linux` executor.

Throughout the codebase, the first logic of each function is creating short variable declarations:

https://github.com/go-vela/pkg-executor/blob/384166ec013a3d18b61b5a4bab43a13dbb32c705/executor/linux/build.go#L24-L27

The problem with this (beyond the extra LOC and variables), is then we are left to update the client with that short variable:

https://github.com/go-vela/pkg-executor/blob/384166ec013a3d18b61b5a4bab43a13dbb32c705/executor/linux/build.go#L50

This attempts to make the variable stored in the client the "source of truth" so to speak since we always reference that.

## Part 2

Introducing a consistent `_<resource>` pattern for the `local` executor variables in the code:

* `_init`
* `_log`
* `_secret`
* `_service`
* `_stage`
* `_step`