### PR TITLE
chore(local): remove unused logs from client

### DIFF
--- a/executor/local/build_test.go
+++ b/executor/local/build_test.go
@@ -380,7 +380,6 @@ func TestLocal_ExecBuild(t *testing.T) {
 			}
 
 			_engine.services.Store(service.ID, s)
-			_engine.serviceLogs.Store(service.ID, new(library.Log))
 		}
 
 		for _, stage := range p.Stages {
@@ -391,7 +390,6 @@ func TestLocal_ExecBuild(t *testing.T) {
 				}
 
 				_engine.steps.Store(step.ID, s)
-				_engine.stepLogs.Store(step.ID, new(library.Log))
 			}
 		}
 
@@ -402,7 +400,6 @@ func TestLocal_ExecBuild(t *testing.T) {
 			}
 
 			_engine.steps.Store(step.ID, s)
-			_engine.stepLogs.Store(step.ID, new(library.Log))
 		}
 
 		// run create to init steps to be created properly

--- a/executor/local/local.go
+++ b/executor/local/local.go
@@ -21,16 +21,14 @@ type (
 		Hostname string
 
 		// private fields
-		init        *pipeline.Container
-		build       *library.Build
-		pipeline    *pipeline.Build
-		repo        *library.Repo
-		services    sync.Map
-		serviceLogs sync.Map
-		steps       sync.Map
-		stepLogs    sync.Map
-		user        *library.User
-		err         error
+		init     *pipeline.Container
+		build    *library.Build
+		pipeline *pipeline.Build
+		repo     *library.Repo
+		services sync.Map
+		steps    sync.Map
+		user     *library.User
+		err      error
 	}
 )
 

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -60,15 +60,6 @@ func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error
 	// add a service to a map
 	c.services.Store(ctn.ID, _service)
 
-	// update the engine service log object
-	_log := new(library.Log)
-	_log.SetBuildID(c.build.GetID())
-	_log.SetRepoID(c.repo.GetID())
-	_log.SetServiceID(_service.GetID())
-
-	// add a service log to a map
-	c.serviceLogs.Store(ctn.ID, _log)
-
 	return nil
 }
 

--- a/executor/local/service_test.go
+++ b/executor/local/service_test.go
@@ -244,7 +244,6 @@ func TestLocal_ExecService(t *testing.T) {
 			t.Errorf("unable to create executor engine: %v", err)
 		}
 
-		_engine.serviceLogs.Store(test.container.ID, new(library.Log))
 		_engine.services.Store(test.container.ID, new(library.Service))
 
 		err = _engine.ExecService(context.Background(), test.container)

--- a/executor/local/stage_test.go
+++ b/executor/local/stage_test.go
@@ -51,7 +51,6 @@ func TestLocal_CreateStage(t *testing.T) {
 	}{
 		{
 			failure: false,
-			logs:    new(library.Log),
 			stage: &pipeline.Stage{
 				Name: "clone",
 				Steps: pipeline.ContainerSlice{
@@ -69,7 +68,6 @@ func TestLocal_CreateStage(t *testing.T) {
 		},
 		{
 			failure: true,
-			logs:    new(library.Log),
 			stage: &pipeline.Stage{
 				Name: "clone",
 				Steps: pipeline.ContainerSlice{
@@ -87,7 +85,6 @@ func TestLocal_CreateStage(t *testing.T) {
 		},
 		{
 			failure: true,
-			logs:    new(library.Log),
 			stage: &pipeline.Stage{
 				Name: "clone",
 				Steps: pipeline.ContainerSlice{
@@ -117,10 +114,6 @@ func TestLocal_CreateStage(t *testing.T) {
 		)
 		if err != nil {
 			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		if test.logs != nil {
-			_engine.stepLogs.Store(_stages.Stages[0].Steps[0].ID, test.logs)
 		}
 
 		_engine.steps.Store(_stages.Stages[0].Steps[0].ID, new(library.Step))
@@ -338,7 +331,6 @@ func TestLocal_ExecStage(t *testing.T) {
 		}
 
 		_engine.steps.Store(_stages.Stages[0].Steps[0].ID, new(library.Step))
-		_engine.stepLogs.Store(_stages.Stages[0].Steps[0].ID, new(library.Log))
 
 		err = _engine.CreateStep(context.Background(), test.stage.Steps[0])
 		if err != nil {

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -61,17 +61,8 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	_step.SetRuntime(ctn.Environment["VELA_RUNTIME"])
 	_step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
 
-	// add a step to a map
+	// add the step to the client map
 	c.steps.Store(ctn.ID, _step)
-
-	// update the engine step log object
-	_log := new(library.Log)
-	_log.SetBuildID(c.build.GetID())
-	_log.SetRepoID(c.repo.GetID())
-	_log.SetStepID(_step.GetID())
-
-	// add a step log to a map
-	c.stepLogs.Store(ctn.ID, _log)
 
 	return nil
 }

--- a/executor/local/step_test.go
+++ b/executor/local/step_test.go
@@ -277,7 +277,6 @@ func TestLocal_ExecStep(t *testing.T) {
 			t.Errorf("unable to create executor engine: %v", err)
 		}
 
-		_engine.stepLogs.Store(test.container.ID, new(library.Log))
 		_engine.steps.Store(test.container.ID, new(library.Step))
 
 		// create volume for runtime host config


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This removes the `serviceLogs` and `stepLogs` fields from the `local` executor client:

https://github.com/go-vela/pkg-executor/blob/384166ec013a3d18b61b5a4bab43a13dbb32c705/executor/local/local.go#L29

https://github.com/go-vela/pkg-executor/blob/384166ec013a3d18b61b5a4bab43a13dbb32c705/executor/local/local.go#L31

These fields are unused since the `local` executor outputs to stdout.