### PR TITLE
refactor: remove hardcoded inspect commands

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -21,7 +21,7 @@ import (
 
 // CreateBuild configures the build for execution.
 func (c *client) CreateBuild(ctx context.Context) error {
-	// defer taking snapshot of build
+	// defer taking a snapshot of the build
 	defer build.Snapshot(c.build, c.Vela, c.err, c.logger, c.repo)
 
 	// update the build fields
@@ -64,7 +64,7 @@ func (c *client) CreateBuild(ctx context.Context) error {
 //
 // nolint: funlen // ignore function length due to comments and logging messages
 func (c *client) PlanBuild(ctx context.Context) error {
-	// defer taking snapshot of build
+	// defer taking a snapshot of the build
 	defer build.Snapshot(c.build, c.Vela, c.err, c.logger, c.repo)
 
 	// load the init step from the client
@@ -188,7 +188,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 // AssembleBuild prepares the containers within a build for execution.
 func (c *client) AssembleBuild(ctx context.Context) error {
-	// defer taking snapshot of build
+	// defer taking a snapshot of the build
 	defer build.Snapshot(c.build, c.Vela, c.err, c.logger, c.repo)
 
 	// load the init step from the client

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -187,6 +187,8 @@ func (c *client) PlanBuild(ctx context.Context) error {
 }
 
 // AssembleBuild prepares the containers within a build for execution.
+//
+// nolint: funlen // ignore function length due to comments and logging messages
 func (c *client) AssembleBuild(ctx context.Context) error {
 	// defer taking a snapshot of the build
 	defer build.Snapshot(c.build, c.Vela, c.err, c.logger, c.repo)

--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -41,13 +41,13 @@ func (s *secretSvc) create(ctx context.Context, ctn *pipeline.Container) error {
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithField
 	logger := s.client.logger.WithField("secret", ctn.Name)
 
-	ctn.Environment["BUILD_HOST"] = s.client.Hostname
-	ctn.Environment["VELA_HOST"] = s.client.Hostname
+	ctn.Environment["VELA_DISTRIBUTION"] = s.client.build.GetDistribution()
+	ctn.Environment["BUILD_HOST"] = s.client.build.GetHost()
+	ctn.Environment["VELA_HOST"] = s.client.build.GetHost()
+	ctn.Environment["VELA_RUNTIME"] = s.client.build.GetRuntime()
 
 	// TODO: remove hardcoded reference
-	ctn.Environment["VELA_VERSION"] = "v0.6.0"
-	ctn.Environment["VELA_RUNTIME"] = "docker"
-	ctn.Environment["VELA_DISTRIBUTION"] = "linux"
+	ctn.Environment["VELA_VERSION"] = "v0.7.0"
 
 	logger.Debug("setting up container")
 	// setup the runtime container

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -35,12 +35,6 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 
 	// create the steps for the stage
 	for _, _step := range s.Steps {
-		// TODO: make this not hardcoded
-		// update the init log with progress
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-		_log.AppendData([]byte(fmt.Sprintf("$ docker image inspect %s\n", _step.Image)))
-
 		logger.Debugf("creating %s step", _step.Name)
 		// create the step
 		err := c.CreateStep(ctx, _step)

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -28,9 +28,8 @@ func (c *client) CreateBuild(ctx context.Context) error {
 	c.build.SetStatus(constants.StatusRunning)
 	c.build.SetStarted(time.Now().UTC().Unix())
 	c.build.SetHost(c.Hostname)
-	// TODO: This should not be hardcoded
 	c.build.SetDistribution(constants.DriverLocal)
-	c.build.SetRuntime("docker")
+	c.build.SetRuntime(c.Runtime.Driver())
 
 	// load the init container from the pipeline
 	c.init = c.loadInitContainer(c.pipeline)
@@ -67,9 +66,6 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	// output init progress to stdout
 	fmt.Fprintln(os.Stdout, _pattern, "> Inspecting runtime network...")
 
-	// output the network command to stdout
-	fmt.Fprintln(os.Stdout, _pattern, "$ docker network inspect", c.pipeline.ID)
-
 	// inspect the runtime network for the pipeline
 	network, err := c.Runtime.InspectNetwork(ctx, c.pipeline)
 	if err != nil {
@@ -89,9 +85,6 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 	// output init progress to stdout
 	fmt.Fprintln(os.Stdout, _pattern, "> Inspecting runtime volume...")
-
-	// output the volume command to stdout
-	fmt.Fprintln(os.Stdout, _pattern, "$ docker volume inspect", c.pipeline.ID)
 
 	// inspect the runtime volume for the pipeline
 	volume, err := c.Runtime.InspectVolume(ctx, c.pipeline)
@@ -138,9 +131,6 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 			return fmt.Errorf("unable to create %s service: %w", _service.Name, c.err)
 		}
 
-		// output the image command to stdout
-		fmt.Fprintln(os.Stdout, _pattern, "$ docker image inspect", _service.Image)
-
 		// inspect the service image
 		image, err := c.Runtime.InspectImage(ctx, _service)
 		if err != nil {
@@ -184,9 +174,6 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		if c.err != nil {
 			return fmt.Errorf("unable to create %s step: %w", _step.Name, c.err)
 		}
-
-		// output the image command to stdout
-		fmt.Fprintln(os.Stdout, _pattern, "$ docker image inspect", _step.Image)
 
 		// inspect the step image
 		image, err := c.Runtime.InspectImage(ctx, _step)

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -21,7 +21,7 @@ import (
 
 // CreateBuild configures the build for execution.
 func (c *client) CreateBuild(ctx context.Context) error {
-	// defer taking snapshot of build
+	// defer taking a snapshot of the build
 	defer build.Snapshot(c.build, nil, c.err, nil, nil)
 
 	// update the build fields
@@ -51,7 +51,7 @@ func (c *client) CreateBuild(ctx context.Context) error {
 
 // PlanBuild prepares the build for execution.
 func (c *client) PlanBuild(ctx context.Context) error {
-	// defer taking snapshot of build
+	// defer taking a snapshot of the build
 	defer build.Snapshot(c.build, nil, c.err, nil, nil)
 
 	// create a step pattern for log output
@@ -101,7 +101,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 
 // AssembleBuild prepares the containers within a build for execution.
 func (c *client) AssembleBuild(ctx context.Context) error {
-	// defer taking snapshot of build
+	// defer taking a snapshot of the build
 	defer build.Snapshot(c.build, nil, c.err, nil, nil)
 
 	// load the init step from the client

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -32,9 +32,6 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 			return err
 		}
 
-		// output image command to stdout
-		fmt.Fprintln(os.Stdout, _pattern, "$ docker image inspect", _step.Image)
-
 		// inspect the step image
 		image, err := c.Runtime.InspectImage(ctx, _step)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-vela/mock v0.7.0-rc1
 	github.com/go-vela/pkg-runtime v0.7.0-rc1.0.20210115210301-627230eab176
 	github.com/go-vela/sdk-go v0.7.0-rc1
-	github.com/go-vela/types v0.7.0-rc1
+	github.com/go-vela/types v0.7.0-rc1.0.20210115155442-682d1037e16d
 	github.com/google/go-cmp v0.5.4
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/go-vela/pkg-executor
 
 go 1.15
 
+replace github.com/go-vela/pkg-runtime => ../pkg-runtime
+
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-vela/compiler v0.7.0-rc1
 	github.com/go-vela/mock v0.7.0-rc1
-	github.com/go-vela/pkg-runtime v0.7.0-rc1
+	github.com/go-vela/pkg-runtime v0.7.0-rc1.0.20210115210301-627230eab176
 	github.com/go-vela/sdk-go v0.7.0-rc1
 	github.com/go-vela/types v0.7.0-rc1
 	github.com/google/go-cmp v0.5.4

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,11 @@ module github.com/go-vela/pkg-executor
 
 go 1.15
 
-replace github.com/go-vela/pkg-runtime => ../pkg-runtime
-
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-vela/compiler v0.7.0-rc1
 	github.com/go-vela/mock v0.7.0-rc1
-	github.com/go-vela/pkg-runtime v0.7.0-rc1.0.20210115210301-627230eab176
+	github.com/go-vela/pkg-runtime v0.7.0-rc1.0.20210119153621-692941980233
 	github.com/go-vela/sdk-go v0.7.0-rc1
 	github.com/go-vela/types v0.7.0-rc1.0.20210115155442-682d1037e16d
 	github.com/google/go-cmp v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/go-vela/compiler v0.7.0-rc1 h1:zXCPEYNqQd4cTOgrz4enTaEAlgkzNQAjSEIOm3
 github.com/go-vela/compiler v0.7.0-rc1/go.mod h1:Q48cLfHUcCHknrqagAJSjL+UpD3CKP4zJ/UgcEpAxzY=
 github.com/go-vela/mock v0.7.0-rc1 h1:Rhb5XWYNxAlL0Nus9CEwrlWx4xOQTwKImKt0xc4i8Rs=
 github.com/go-vela/mock v0.7.0-rc1/go.mod h1:diiACzMDRowQH/ayauz7c7YSRsqOHwaoC8V0rgO3qIs=
+github.com/go-vela/pkg-runtime v0.7.0-rc1.0.20210119153621-692941980233 h1:1Rb1a0Vh1OwiKyRWIxAFOSq7TG4J56S7CFdQtXOn+G4=
+github.com/go-vela/pkg-runtime v0.7.0-rc1.0.20210119153621-692941980233/go.mod h1:8+czYfus3uOYKFSGbaazO/wNbv1O1w61J9MPouZX9hw=
 github.com/go-vela/sdk-go v0.7.0-rc1 h1:cPiJH1FMfN9GjA3BGrPs0CE1/D+m8/5141BH+ojARIk=
 github.com/go-vela/sdk-go v0.7.0-rc1/go.mod h1:vhXS1robNh5fL6D5Iel+rmcNH1fkbhxcQL65t8AvwD0=
 github.com/go-vela/types v0.7.0-rc1 h1:Q16xpyfLD3uc20mDimidjQoSwi7HG7ukfYJs74I/XHY=

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/go-vela/sdk-go v0.7.0-rc1 h1:cPiJH1FMfN9GjA3BGrPs0CE1/D+m8/5141BH+ojA
 github.com/go-vela/sdk-go v0.7.0-rc1/go.mod h1:vhXS1robNh5fL6D5Iel+rmcNH1fkbhxcQL65t8AvwD0=
 github.com/go-vela/types v0.7.0-rc1 h1:Q16xpyfLD3uc20mDimidjQoSwi7HG7ukfYJs74I/XHY=
 github.com/go-vela/types v0.7.0-rc1/go.mod h1:ATtwTwp2l4jI4GUmw840xHZgHmg8FbZPo4g0azImggA=
+github.com/go-vela/types v0.7.0-rc1.0.20210115155442-682d1037e16d h1:TJ6ZOLmPN02UcDDJNnzDlYNB3xwev6mojN7ekvV+ZXI=
+github.com/go-vela/types v0.7.0-rc1.0.20210115155442-682d1037e16d/go.mod h1:ATtwTwp2l4jI4GUmw840xHZgHmg8FbZPo4g0azImggA=
 github.com/goccy/go-yaml v1.8.4 h1:AOEdR7aQgbgwHznGe3BLkDQVujxCPUpHOZZcQcp8Y3M=
 github.com/goccy/go-yaml v1.8.4/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -500,6 +502,8 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061 h1:DQmQoKxQWtyybCtX/3dIuDBcAhFszqq8YiNeS6sNu1c=
 golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ github.com/go-vela/compiler v0.7.0-rc1 h1:zXCPEYNqQd4cTOgrz4enTaEAlgkzNQAjSEIOm3
 github.com/go-vela/compiler v0.7.0-rc1/go.mod h1:Q48cLfHUcCHknrqagAJSjL+UpD3CKP4zJ/UgcEpAxzY=
 github.com/go-vela/mock v0.7.0-rc1 h1:Rhb5XWYNxAlL0Nus9CEwrlWx4xOQTwKImKt0xc4i8Rs=
 github.com/go-vela/mock v0.7.0-rc1/go.mod h1:diiACzMDRowQH/ayauz7c7YSRsqOHwaoC8V0rgO3qIs=
-github.com/go-vela/pkg-runtime v0.7.0-rc1 h1:x2i3k1e4Wn42ucJGEGsLbRYMiTlijl82cC3fuKdXWXg=
-github.com/go-vela/pkg-runtime v0.7.0-rc1/go.mod h1:74JdqWBthhuTeIvYMfIkhuMb8plsRHdVTjCBoVY8kYQ=
 github.com/go-vela/sdk-go v0.7.0-rc1 h1:cPiJH1FMfN9GjA3BGrPs0CE1/D+m8/5141BH+ojARIk=
 github.com/go-vela/sdk-go v0.7.0-rc1/go.mod h1:vhXS1robNh5fL6D5Iel+rmcNH1fkbhxcQL65t8AvwD0=
 github.com/go-vela/types v0.7.0-rc1 h1:Q16xpyfLD3uc20mDimidjQoSwi7HG7ukfYJs74I/XHY=


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

Dependent on https://github.com/go-vela/pkg-runtime/pull/77

This will remove any hardcoded references to inspecting runtime resources which is tracked via the `init` process:

https://github.com/go-vela/pkg-executor/blob/3fbd5e5f77b213f31fbed8f7910b5efaa287e963/executor/linux/build.go#L115-L126

The above code refactored, now looks like:

https://github.com/go-vela/pkg-executor/blob/d084c8258d8e8c30d99f10ee7ca80959e2373ccd/executor/linux/build.go#L114-L124