### PR TITLE
feat(internal): add step.Snapshot() function

### DIFF
--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -286,54 +286,14 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 		_step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
 	}
 
-	defer func() {
-		logger.Info("uploading step snapshot")
-		// send API call to update the step
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err := c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), _step)
-		if err != nil {
-			logger.Errorf("unable to upload step snapshot: %v", err)
-		}
-	}()
-
-	// check if the step is in a pending state
-	if _step.GetStatus() == constants.StatusPending {
-		// update the step fields
-		//
-		// TODO: consider making this a constant
-		//
-		// nolint: gomnd // ignore magic number 137
-		_step.SetExitCode(137)
-		_step.SetFinished(time.Now().UTC().Unix())
-		_step.SetStatus(constants.StatusKilled)
-
-		// check if the step was not started
-		if _step.GetStarted() == 0 {
-			// set the started time to the finished time
-			_step.SetStarted(_step.GetFinished())
-		}
-	}
+	// defer taking a snapshot of the step
+	defer step.Snapshot(ctn, c.build, c.Vela, logger, c.repo, _step)
 
 	logger.Debug("inspecting container")
 	// inspect the runtime container
 	err = c.Runtime.InspectContainer(ctx, ctn)
 	if err != nil {
 		return err
-	}
-
-	// check if the step finished
-	if _step.GetFinished() == 0 {
-		// update the step fields
-		_step.SetFinished(time.Now().UTC().Unix())
-		_step.SetStatus(constants.StatusSuccess)
-
-		// check the container for an unsuccessful exit code
-		if ctn.ExitCode > 0 {
-			// update the step fields
-			_step.SetExitCode(ctn.ExitCode)
-			_step.SetStatus(constants.StatusFailure)
-		}
 	}
 
 	logger.Debug("removing container")

--- a/internal/step/snapshot.go
+++ b/internal/step/snapshot.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package step
+
+import (
+	"time"
+
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+	"github.com/sirupsen/logrus"
+)
+
+// Snapshot creates a moment in time record of the step
+// and attempts to upload it to the server.
+func Snapshot(ctn *pipeline.Container, b *library.Build, c *vela.Client, l *logrus.Entry, r *library.Repo, s *library.Step) {
+	// check if the logger provided is empty
+	if l == nil {
+		l = logrus.NewEntry(logrus.StandardLogger())
+	}
+
+	// check if the step is in a pending state
+	if s.GetStatus() == constants.StatusPending {
+		// update the step fields
+		//
+		// TODO: consider making this a constant
+		//
+		// nolint: gomnd // ignore magic number 137
+		s.SetExitCode(137)
+		s.SetFinished(time.Now().UTC().Unix())
+		s.SetStatus(constants.StatusKilled)
+
+		// check if the step was not started
+		if s.GetStarted() == 0 {
+			// set the started time to the finished time
+			s.SetStarted(s.GetFinished())
+		}
+	}
+
+	// check if the step finished
+	if s.GetFinished() == 0 {
+		// update the step fields
+		s.SetFinished(time.Now().UTC().Unix())
+		s.SetStatus(constants.StatusSuccess)
+
+		// check the container for an unsuccessful exit code
+		if ctn.ExitCode > 0 {
+			// update the step fields
+			s.SetExitCode(ctn.ExitCode)
+			s.SetStatus(constants.StatusFailure)
+		}
+	}
+
+	// check if the Vela client provided is empty
+	if c != nil {
+		l.Debug("uploading step snapshot")
+
+		// send API call to update the step
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
+		_, _, err := c.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+		if err != nil {
+			l.Errorf("unable to upload step snapshot: %v", err)
+		}
+	}
+}

--- a/internal/step/snapshot_test.go
+++ b/internal/step/snapshot_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package step
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/mock/server"
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestStep_Snapshot(t *testing.T) {
+	// setup types
+	_build := &library.Build{
+		ID:           vela.Int64(1),
+		Number:       vela.Int(1),
+		Parent:       vela.Int(1),
+		Event:        vela.String("push"),
+		Status:       vela.String("success"),
+		Error:        vela.String(""),
+		Enqueued:     vela.Int64(1563474077),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(1563474077),
+		Finished:     vela.Int64(0),
+		Deploy:       vela.String(""),
+		Clone:        vela.String("https://github.com/github/octocat.git"),
+		Source:       vela.String("https://github.com/github/octocat/abcdefghi123456789"),
+		Title:        vela.String("push received from https://github.com/github/octocat"),
+		Message:      vela.String("First commit..."),
+		Commit:       vela.String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Sender:       vela.String("OctoKitty"),
+		Author:       vela.String("OctoKitty"),
+		Branch:       vela.String("master"),
+		Ref:          vela.String("refs/heads/master"),
+		BaseRef:      vela.String(""),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	_container := &pipeline.Container{
+		ID:          "step_github_octocat_1_init",
+		Directory:   "/home/github/octocat",
+		Environment: map[string]string{"FOO": "bar"},
+		Image:       "#init",
+		Name:        "init",
+		Number:      1,
+		Pull:        "always",
+	}
+
+	_exitCode := &pipeline.Container{
+		ID:          "step_github_octocat_1_init",
+		Directory:   "/home/github/octocat",
+		Environment: map[string]string{"FOO": "bar"},
+		ExitCode:    137,
+		Image:       "#init",
+		Name:        "init",
+		Number:      1,
+		Pull:        "always",
+	}
+
+	_repo := &library.Repo{
+		ID:          vela.Int64(1),
+		Org:         vela.String("github"),
+		Name:        vela.String("octocat"),
+		FullName:    vela.String("github/octocat"),
+		Link:        vela.String("https://github.com/github/octocat"),
+		Clone:       vela.String("https://github.com/github/octocat.git"),
+		Branch:      vela.String("master"),
+		Timeout:     vela.Int64(60),
+		Visibility:  vela.String("public"),
+		Private:     vela.Bool(false),
+		Trusted:     vela.Bool(false),
+		Active:      vela.Bool(true),
+		AllowPull:   vela.Bool(false),
+		AllowPush:   vela.Bool(true),
+		AllowDeploy: vela.Bool(false),
+		AllowTag:    vela.Bool(false),
+	}
+
+	_step := &library.Step{
+		ID:           vela.Int64(1),
+		BuildID:      vela.Int64(1),
+		RepoID:       vela.Int64(1),
+		Number:       vela.Int(1),
+		Name:         vela.String("clone"),
+		Image:        vela.String("target/vela-git:v0.3.0"),
+		Status:       vela.String("pending"),
+		ExitCode:     vela.Int(0),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(0),
+		Finished:     vela.Int64(1563474079),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, "", nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	tests := []struct {
+		build     *library.Build
+		client    *vela.Client
+		container *pipeline.Container
+		repo      *library.Repo
+		step      *library.Step
+	}{
+		{
+			build:     _build,
+			client:    _client,
+			container: _container,
+			repo:      _repo,
+			step:      _step,
+		},
+		{
+			build:     _build,
+			client:    _client,
+			container: _exitCode,
+			repo:      _repo,
+			step:      nil,
+		},
+	}
+
+	// run test
+	for _, test := range tests {
+		Snapshot(test.container, test.build, test.client, nil, test.repo, test.step)
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds a new `step.Snapshot()` function to the `go-vela/pkg-executor/internal/step` package.

The intention of this function is to create an instantaneous record of the step and upload it to Vela.

This benefits us by reducing the non-test LOC in the executor codebase:

https://github.com/go-vela/pkg-executor/blob/5230079566611352902352b85950588afeb2b930/internal/step/snapshot.go#L17-L69