### PR TITLE
feat(internal): add service.Snapshot() function

### DIFF
--- a/internal/service/snapshot.go
+++ b/internal/service/snapshot.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package service
+
+import (
+	"time"
+
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+	"github.com/sirupsen/logrus"
+)
+
+// Snapshot creates a moment in time record of the service
+// and attempts to upload it to the server.
+func Snapshot(ctn *pipeline.Container, b *library.Build, c *vela.Client, l *logrus.Entry, r *library.Repo, s *library.Service) {
+	// check if the logger provided is empty
+	if l == nil {
+		l = logrus.NewEntry(logrus.StandardLogger())
+	}
+
+	// check if the service is in a pending state
+	if s.GetStatus() == constants.StatusPending {
+		// update the service fields
+		//
+		// TODO: consider making this a constant
+		//
+		// nolint: gomnd // ignore magic number 137
+		s.SetExitCode(137)
+		s.SetFinished(time.Now().UTC().Unix())
+		s.SetStatus(constants.StatusKilled)
+
+		// check if the service was not started
+		if s.GetStarted() == 0 {
+			// set the started time to the finished time
+			s.SetStarted(s.GetFinished())
+		}
+	}
+
+	// check if the service finished
+	if s.GetFinished() == 0 {
+		// update the service fields
+		s.SetFinished(time.Now().UTC().Unix())
+		s.SetStatus(constants.StatusSuccess)
+
+		// check the container for an unsuccessful exit code
+		if ctn.ExitCode > 0 {
+			// update the service fields
+			s.SetExitCode(ctn.ExitCode)
+			s.SetStatus(constants.StatusFailure)
+		}
+	}
+
+	// check if the Vela client provided is empty
+	if c != nil {
+		l.Debug("uploading service snapshot")
+
+		// send API call to update the service
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#SvcService.Update
+		_, _, err := c.Svc.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+		if err != nil {
+			l.Errorf("unable to upload service snapshot: %v", err)
+		}
+	}
+}

--- a/internal/service/snapshot_test.go
+++ b/internal/service/snapshot_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package service
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/mock/server"
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestService_Snapshot(t *testing.T) {
+	// setup types
+	_build := &library.Build{
+		ID:           vela.Int64(1),
+		Number:       vela.Int(1),
+		Parent:       vela.Int(1),
+		Event:        vela.String("push"),
+		Status:       vela.String("success"),
+		Error:        vela.String(""),
+		Enqueued:     vela.Int64(1563474077),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(1563474077),
+		Finished:     vela.Int64(0),
+		Deploy:       vela.String(""),
+		Clone:        vela.String("https://github.com/github/octocat.git"),
+		Source:       vela.String("https://github.com/github/octocat/abcdefghi123456789"),
+		Title:        vela.String("push received from https://github.com/github/octocat"),
+		Message:      vela.String("First commit..."),
+		Commit:       vela.String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Sender:       vela.String("OctoKitty"),
+		Author:       vela.String("OctoKitty"),
+		Branch:       vela.String("master"),
+		Ref:          vela.String("refs/heads/master"),
+		BaseRef:      vela.String(""),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	_container := &pipeline.Container{
+		ID:          "step_github_octocat_1_init",
+		Directory:   "/home/github/octocat",
+		Environment: map[string]string{"FOO": "bar"},
+		Image:       "#init",
+		Name:        "init",
+		Number:      1,
+		Pull:        "always",
+	}
+
+	_exitCode := &pipeline.Container{
+		ID:          "step_github_octocat_1_init",
+		Directory:   "/home/github/octocat",
+		Environment: map[string]string{"FOO": "bar"},
+		ExitCode:    137,
+		Image:       "#init",
+		Name:        "init",
+		Number:      1,
+		Pull:        "always",
+	}
+
+	_repo := &library.Repo{
+		ID:          vela.Int64(1),
+		Org:         vela.String("github"),
+		Name:        vela.String("octocat"),
+		FullName:    vela.String("github/octocat"),
+		Link:        vela.String("https://github.com/github/octocat"),
+		Clone:       vela.String("https://github.com/github/octocat.git"),
+		Branch:      vela.String("master"),
+		Timeout:     vela.Int64(60),
+		Visibility:  vela.String("public"),
+		Private:     vela.Bool(false),
+		Trusted:     vela.Bool(false),
+		Active:      vela.Bool(true),
+		AllowPull:   vela.Bool(false),
+		AllowPush:   vela.Bool(true),
+		AllowDeploy: vela.Bool(false),
+		AllowTag:    vela.Bool(false),
+	}
+
+	_service := &library.Service{
+		ID:           vela.Int64(1),
+		BuildID:      vela.Int64(1),
+		RepoID:       vela.Int64(1),
+		Number:       vela.Int(1),
+		Name:         vela.String("postgres"),
+		Image:        vela.String("postgres:12-alpine"),
+		Status:       vela.String("pending"),
+		ExitCode:     vela.Int(0),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(0),
+		Finished:     vela.Int64(1563474079),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, "", nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	tests := []struct {
+		build     *library.Build
+		client    *vela.Client
+		container *pipeline.Container
+		repo      *library.Repo
+		service   *library.Service
+	}{
+		{
+			build:     _build,
+			client:    _client,
+			container: _container,
+			repo:      _repo,
+			service:   _service,
+		},
+		{
+			build:     _build,
+			client:    _client,
+			container: _exitCode,
+			repo:      _repo,
+			service:   nil,
+		},
+	}
+
+	// run test
+	for _, test := range tests {
+		Snapshot(test.container, test.build, test.client, nil, test.repo, test.service)
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds a new `service.Snapshot()` function to the `go-vela/pkg-executor/internal/service` package.

The intention of this function is to create an instantaneous record of the service and upload it to Vela.

This benefits us by reducing the non-test LOC in the executor codebase:

https://github.com/go-vela/pkg-executor/blob/49441eb159552016029336ad4ebe78800c3f9620/internal/service/snapshot.go#L17-L69