### PR TITLE
feat(local): add api executor functions

### DIFF
--- a/executor/linux/api.go
+++ b/executor/linux/api.go
@@ -16,47 +16,40 @@ import (
 
 // GetBuild gets the current build in execution.
 func (c *client) GetBuild() (*library.Build, error) {
-	b := c.build
-
 	// check if the build resource is available
-	if b == nil {
+	if c.build == nil {
 		return nil, fmt.Errorf("build resource not found")
 	}
 
-	return b, nil
+	return c.build, nil
 }
 
 // GetPipeline gets the current pipeline in execution.
 func (c *client) GetPipeline() (*pipeline.Build, error) {
-	p := c.pipeline
-
 	// check if the pipeline resource is available
-	if p == nil {
+	if c.pipeline == nil {
 		return nil, fmt.Errorf("pipeline resource not found")
 	}
 
-	return p, nil
+	return c.pipeline, nil
 }
 
 // GetRepo gets the current repo in execution.
 func (c *client) GetRepo() (*library.Repo, error) {
-	r := c.repo
-
 	// check if the repo resource is available
-	if r == nil {
+	if c.repo == nil {
 		return nil, fmt.Errorf("repo resource not found")
 	}
 
-	return r, nil
+	return c.repo, nil
 }
 
 // CancelBuild cancels the current build in execution.
 func (c *client) CancelBuild() (*library.Build, error) {
-	b := c.build
-
-	// check if the build resource is available
-	if b == nil {
-		return nil, fmt.Errorf("build resource not found")
+	// get the current build from the client
+	b, err := c.GetBuild()
+	if err != nil {
+		return nil, err
 	}
 
 	// set the build status to killed

--- a/executor/local/api.go
+++ b/executor/local/api.go
@@ -5,26 +5,65 @@
 package local
 
 import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
 )
 
 // GetBuild gets the current build in execution.
 func (c *client) GetBuild() (*library.Build, error) {
-	return nil, nil
+	// check if the build resource is available
+	if c.build == nil {
+		return nil, fmt.Errorf("build resource not found")
+	}
+
+	return c.build, nil
 }
 
 // GetPipeline gets the current pipeline in execution.
 func (c *client) GetPipeline() (*pipeline.Build, error) {
-	return nil, nil
+	// check if the pipeline resource is available
+	if c.pipeline == nil {
+		return nil, fmt.Errorf("pipeline resource not found")
+	}
+
+	return c.pipeline, nil
 }
 
 // GetRepo gets the current repo in execution.
 func (c *client) GetRepo() (*library.Repo, error) {
-	return nil, nil
+	// check if the repo resource is available
+	if c.repo == nil {
+		return nil, fmt.Errorf("repo resource not found")
+	}
+
+	return c.repo, nil
 }
 
 // CancelBuild cancels the current build in execution.
 func (c *client) CancelBuild() (*library.Build, error) {
-	return nil, nil
+	// get the current build from the client
+	b, err := c.GetBuild()
+	if err != nil {
+		return nil, err
+	}
+
+	// set the build status to killed
+	b.SetStatus(constants.StatusCanceled)
+
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return nil, fmt.Errorf("unable to find PID: %v", err)
+	}
+
+	err = p.Signal(syscall.SIGTERM)
+	if err != nil {
+		return nil, fmt.Errorf("unable to cancel PID: %v", err)
+	}
+
+	return b, nil
 }

--- a/executor/local/api_test.go
+++ b/executor/local/api_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package local
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLocal_GetBuild(t *testing.T) {
+	// setup types
+	_build := testBuild()
+
+	_engine, err := New(
+		WithBuild(_build),
+	)
+	if err != nil {
+		t.Errorf("unable to create executor engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		engine  *client
+	}{
+		{
+			failure: false,
+			engine:  _engine,
+		},
+		{
+			failure: true,
+			engine:  new(client),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := test.engine.GetBuild()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuild should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuild returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, _build) {
+			t.Errorf("GetBuild is %v, want %v", got, _build)
+		}
+	}
+}
+
+func TestLocal_GetPipeline(t *testing.T) {
+	// setup types
+	_steps := testSteps()
+
+	_engine, err := New(
+		WithPipeline(_steps),
+	)
+	if err != nil {
+		t.Errorf("unable to create executor engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		engine  *client
+	}{
+		{
+			failure: false,
+			engine:  _engine,
+		},
+		{
+			failure: true,
+			engine:  new(client),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := test.engine.GetPipeline()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetPipeline should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetPipeline returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, _steps) {
+			t.Errorf("GetPipeline is %v, want %v", got, _steps)
+		}
+	}
+}
+
+func TestLocal_GetRepo(t *testing.T) {
+	// setup types
+	_repo := testRepo()
+
+	_engine, err := New(
+		WithRepo(_repo),
+	)
+	if err != nil {
+		t.Errorf("unable to create executor engine: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		engine  *client
+	}{
+		{
+			failure: false,
+			engine:  _engine,
+		},
+		{
+			failure: true,
+			engine:  new(client),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := test.engine.GetRepo()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepo should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepo returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, _repo) {
+			t.Errorf("GetRepo is %v, want %v", got, _repo)
+		}
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This implements the API based functions for the `local` executor.

The functions added here are:

* [GetBuild()](https://github.com/go-vela/pkg-executor/blob/29634d7c0d04fca71d141dbd56a30c67f81e6728/executor/local/api.go#L17-L25)
* [GetPipeline()](https://github.com/go-vela/pkg-executor/blob/29634d7c0d04fca71d141dbd56a30c67f81e6728/executor/local/api.go#L27-L35)
* [GetRepo()](https://github.com/go-vela/pkg-executor/blob/29634d7c0d04fca71d141dbd56a30c67f81e6728/executor/local/api.go#L37-L45)
* [CancelBuild()](https://github.com/go-vela/pkg-executor/blob/29634d7c0d04fca71d141dbd56a30c67f81e6728/executor/local/api.go#L47-L69)