### PR TITLE
feat(internal): add step.Skip() function

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-vela/pkg-executor/internal/build"
 	"github.com/go-vela/pkg-executor/internal/step"
 	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/pipeline"
 )
 
 // CreateBuild configures the build for execution.
@@ -415,26 +414,8 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			continue
 		}
 
-		// extract rule data from build information
-		ruledata := &pipeline.RuleData{
-			Branch: c.build.GetBranch(),
-			Event:  c.build.GetEvent(),
-			Repo:   c.repo.GetFullName(),
-			Status: c.build.GetStatus(),
-		}
-
-		// when tag event add tag information into ruledata
-		if strings.EqualFold(c.build.GetEvent(), constants.EventTag) {
-			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
-		}
-
-		// when deployment event add deployment information into ruledata
-		if strings.EqualFold(c.build.GetEvent(), constants.EventDeploy) {
-			ruledata.Target = c.build.GetDeploy()
-		}
-
-		// check if you need to excute this step
-		if !_step.Execute(ruledata) {
+		// check if you need to skip executing this step
+		if step.Skip(_step, c.build, c.repo) {
 			continue
 		}
 

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -7,7 +7,6 @@ package linux
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-vela/pkg-executor/internal/step"
@@ -106,26 +105,8 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 	logger.Debug("starting execution of stage")
 	// execute the steps for the stage
 	for _, _step := range s.Steps {
-		// extract rule data from build information
-		ruledata := &pipeline.RuleData{
-			Branch: c.build.GetBranch(),
-			Event:  c.build.GetEvent(),
-			Repo:   c.repo.GetFullName(),
-			Status: c.build.GetStatus(),
-		}
-
-		// when tag event add tag information into ruledata
-		if strings.EqualFold(c.build.GetEvent(), constants.EventTag) {
-			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
-		}
-
-		// when deployment event add deployment information into ruledata
-		if strings.EqualFold(c.build.GetEvent(), constants.EventDeploy) {
-			ruledata.Target = c.build.GetDeploy()
-		}
-
-		// check if you need to excute this step
-		if !_step.Execute(ruledata) {
+		// check if you need to skip executing this step
+		if step.Skip(_step, c.build, c.repo) {
 			continue
 		}
 

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-vela/pkg-executor/internal/build"
 	"github.com/go-vela/pkg-executor/internal/step"
 	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/pipeline"
 )
 
 // CreateBuild configures the build for execution.
@@ -239,26 +238,8 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			continue
 		}
 
-		// extract rule data from build information
-		ruledata := &pipeline.RuleData{
-			Branch: c.build.GetBranch(),
-			Event:  c.build.GetEvent(),
-			Repo:   c.repo.GetFullName(),
-			Status: c.build.GetStatus(),
-		}
-
-		// when tag event add tag information into ruledata
-		if strings.EqualFold(c.build.GetEvent(), constants.EventTag) {
-			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
-		}
-
-		// when deployment event add deployment information into ruledata
-		if strings.EqualFold(c.build.GetEvent(), constants.EventDeploy) {
-			ruledata.Target = c.build.GetDeploy()
-		}
-
-		// check if you need to excute this step
-		if !_step.Execute(ruledata) {
+		// check if you need to skip executing this step
+		if step.Skip(_step, c.build, c.repo) {
 			continue
 		}
 

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/go-vela/pkg-executor/internal/step"
@@ -78,26 +77,8 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 
 	// execute the steps for the stage
 	for _, _step := range s.Steps {
-		// extract rule data from build information
-		ruledata := &pipeline.RuleData{
-			Branch: c.build.GetBranch(),
-			Event:  c.build.GetEvent(),
-			Repo:   c.repo.GetFullName(),
-			Status: c.build.GetStatus(),
-		}
-
-		// when tag event add tag information into ruledata
-		if strings.EqualFold(c.build.GetEvent(), constants.EventTag) {
-			ruledata.Tag = strings.TrimPrefix(c.build.GetRef(), "refs/tags/")
-		}
-
-		// when deployment event add deployment information into ruledata
-		if strings.EqualFold(c.build.GetEvent(), constants.EventDeploy) {
-			ruledata.Target = c.build.GetDeploy()
-		}
-
-		// check if you need to excute this step
-		if !_step.Execute(ruledata) {
+		// check if you need to skip executing this step
+		if step.Skip(_step, c.build, c.repo) {
 			continue
 		}
 

--- a/internal/step/skip.go
+++ b/internal/step/skip.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package step
+
+import (
+	"strings"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+// Skip creates the ruledata from the build and repository
+// information and returns true if the data does not match
+// the ruleset for the given container.
+func Skip(c *pipeline.Container, b *library.Build, r *library.Repo) bool {
+	// check if the container provided is empty
+	if c == nil {
+		return true
+	}
+
+	// create ruledata from build and repository information
+	ruledata := &pipeline.RuleData{
+		Branch: b.GetBranch(),
+		Event:  b.GetEvent(),
+		Repo:   r.GetFullName(),
+		Status: b.GetStatus(),
+	}
+
+	// check if the build event is tag
+	if strings.EqualFold(b.GetEvent(), constants.EventTag) {
+		// add tag information to ruledata with refs/tags prefix removed
+		ruledata.Tag = strings.TrimPrefix(b.GetRef(), "refs/tags/")
+	}
+
+	// check if the build event is deployment
+	if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
+		// add deployment target information to ruledata
+		ruledata.Target = b.GetDeploy()
+	}
+
+	// return the inverse of container execute
+	return !c.Execute(ruledata)
+}

--- a/internal/step/skip_test.go
+++ b/internal/step/skip_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package step
+
+import (
+	"testing"
+
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestStep_Skip(t *testing.T) {
+	// setup types
+	_build := &library.Build{
+		ID:           vela.Int64(1),
+		Number:       vela.Int(1),
+		Parent:       vela.Int(1),
+		Event:        vela.String("push"),
+		Status:       vela.String("success"),
+		Error:        vela.String(""),
+		Enqueued:     vela.Int64(1563474077),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(1563474077),
+		Finished:     vela.Int64(0),
+		Deploy:       vela.String(""),
+		Clone:        vela.String("https://github.com/github/octocat.git"),
+		Source:       vela.String("https://github.com/github/octocat/abcdefghi123456789"),
+		Title:        vela.String("push received from https://github.com/github/octocat"),
+		Message:      vela.String("First commit..."),
+		Commit:       vela.String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Sender:       vela.String("OctoKitty"),
+		Author:       vela.String("OctoKitty"),
+		Branch:       vela.String("master"),
+		Ref:          vela.String("refs/heads/master"),
+		BaseRef:      vela.String(""),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	_deploy := &library.Build{
+		ID:           vela.Int64(1),
+		Number:       vela.Int(1),
+		Parent:       vela.Int(1),
+		Event:        vela.String("deployment"),
+		Status:       vela.String("success"),
+		Error:        vela.String(""),
+		Enqueued:     vela.Int64(1563474077),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(1563474077),
+		Finished:     vela.Int64(0),
+		Deploy:       vela.String(""),
+		Clone:        vela.String("https://github.com/github/octocat.git"),
+		Source:       vela.String("https://github.com/github/octocat/abcdefghi123456789"),
+		Title:        vela.String("push received from https://github.com/github/octocat"),
+		Message:      vela.String("First commit..."),
+		Commit:       vela.String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Sender:       vela.String("OctoKitty"),
+		Author:       vela.String("OctoKitty"),
+		Branch:       vela.String("master"),
+		Ref:          vela.String("refs/heads/master"),
+		BaseRef:      vela.String(""),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	_tag := &library.Build{
+		ID:           vela.Int64(1),
+		Number:       vela.Int(1),
+		Parent:       vela.Int(1),
+		Event:        vela.String("tag"),
+		Status:       vela.String("success"),
+		Error:        vela.String(""),
+		Enqueued:     vela.Int64(1563474077),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(1563474077),
+		Finished:     vela.Int64(0),
+		Deploy:       vela.String(""),
+		Clone:        vela.String("https://github.com/github/octocat.git"),
+		Source:       vela.String("https://github.com/github/octocat/abcdefghi123456789"),
+		Title:        vela.String("push received from https://github.com/github/octocat"),
+		Message:      vela.String("First commit..."),
+		Commit:       vela.String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Sender:       vela.String("OctoKitty"),
+		Author:       vela.String("OctoKitty"),
+		Branch:       vela.String("master"),
+		Ref:          vela.String("refs/heads/master"),
+		BaseRef:      vela.String(""),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	_container := &pipeline.Container{
+		ID:          "step_github_octocat_1_init",
+		Directory:   "/home/github/octocat",
+		Environment: map[string]string{"FOO": "bar"},
+		Image:       "#init",
+		Name:        "init",
+		Number:      1,
+		Pull:        "always",
+	}
+
+	_repo := &library.Repo{
+		ID:          vela.Int64(1),
+		Org:         vela.String("github"),
+		Name:        vela.String("octocat"),
+		FullName:    vela.String("github/octocat"),
+		Link:        vela.String("https://github.com/github/octocat"),
+		Clone:       vela.String("https://github.com/github/octocat.git"),
+		Branch:      vela.String("master"),
+		Timeout:     vela.Int64(60),
+		Visibility:  vela.String("public"),
+		Private:     vela.Bool(false),
+		Trusted:     vela.Bool(false),
+		Active:      vela.Bool(true),
+		AllowPull:   vela.Bool(false),
+		AllowPush:   vela.Bool(true),
+		AllowDeploy: vela.Bool(false),
+		AllowTag:    vela.Bool(false),
+	}
+
+	tests := []struct {
+		build     *library.Build
+		container *pipeline.Container
+		repo      *library.Repo
+		want      bool
+	}{
+		{
+			build:     _build,
+			container: _container,
+			repo:      _repo,
+			want:      false,
+		},
+		{
+			build:     _deploy,
+			container: _container,
+			repo:      _repo,
+			want:      false,
+		},
+		{
+			build:     _tag,
+			container: _container,
+			repo:      _repo,
+			want:      false,
+		},
+		{
+			build:     nil,
+			container: nil,
+			repo:      nil,
+			want:      true,
+		},
+	}
+
+	// run test
+	for _, test := range tests {
+		got := Skip(test.container, test.build, test.repo)
+
+		if got != test.want {
+			t.Errorf("Skip is %v, want %v", got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds a new `step.Skip()` function to the `go-vela/pkg-executor/internal/step` package.

The intention of this function is to create the ruledata from the llbrary resources and verify the container for the step should be executed.

https://github.com/go-vela/pkg-executor/blob/621ca0a7bb301d3fd403d4a6e67820a97054a1a8/internal/step/skip.go#L15-L46