### PR TITLE
feat(local): add logging pattern for stages

### DIFF
--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -68,11 +68,12 @@ func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error
 	_service := new(library.Service)
 	_service.SetName(ctn.Name)
 	_service.SetNumber(ctn.Number)
+	_service.SetImage(ctn.Image)
 	_service.SetStatus(constants.StatusRunning)
 	_service.SetStarted(time.Now().UTC().Unix())
-	_service.SetHost(ctn.Environment["VELA_HOST"])
-	_service.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-	_service.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+	_service.SetHost(c.build.GetHost())
+	_service.SetRuntime(c.build.GetRuntime())
+	_service.SetDistribution(c.build.GetDistribution())
 
 	logger.Debug("uploading service state")
 	// send API call to update the service
@@ -238,13 +239,7 @@ func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) er
 	_service, err := service.Load(ctn, &c.services)
 	if err != nil {
 		// create the service from the container
-		_service = new(library.Service)
-		_service.SetName(ctn.Name)
-		_service.SetNumber(ctn.Number)
-		_service.SetStatus(constants.StatusPending)
-		_service.SetHost(ctn.Environment["VELA_HOST"])
-		_service.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-		_service.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+		_service = library.ServiceFromContainer(ctn)
 	}
 
 	// defer taking a snapshot of the service

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -34,6 +34,9 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 
 	// create the steps for the stage
 	for _, _step := range s.Steps {
+		// update the container environment with stage name
+		_step.Environment["VELA_STEP_STAGE"] = s.Name
+
 		logger.Debugf("creating %s step", _step.Name)
 		// create the step
 		err := c.CreateStep(ctx, _step)

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -56,6 +56,12 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	// create a step pattern for log output
 	_pattern := fmt.Sprintf(stepPattern, c.init.Name)
 
+	// check if the pipeline provided has stages
+	if len(c.pipeline.Stages) > 0 {
+		// create a stage pattern for log output
+		_pattern = fmt.Sprintf(stagePattern, c.init.Name, c.init.Name)
+	}
+
 	// create the runtime network for the pipeline
 	c.err = c.Runtime.CreateNetwork(ctx, c.pipeline)
 	if c.err != nil {
@@ -111,6 +117,12 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 	// create a step pattern for log output
 	_pattern := fmt.Sprintf(stepPattern, c.init.Name)
+
+	// check if the pipeline provided has stages
+	if len(c.pipeline.Stages) > 0 {
+		// create a stage pattern for log output
+		_pattern = fmt.Sprintf(stagePattern, c.init.Name, c.init.Name)
+	}
 
 	defer func() {
 		_init.SetFinished(time.Now().UTC().Unix())

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -50,11 +50,12 @@ func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error
 	_service := new(library.Service)
 	_service.SetName(ctn.Name)
 	_service.SetNumber(ctn.Number)
+	_service.SetImage(ctn.Image)
 	_service.SetStatus(constants.StatusRunning)
 	_service.SetStarted(time.Now().UTC().Unix())
-	_service.SetHost(ctn.Environment["VELA_HOST"])
-	_service.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-	_service.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+	_service.SetHost(c.build.GetHost())
+	_service.SetRuntime(c.build.GetRuntime())
+	_service.SetDistribution(c.build.GetDistribution())
 
 	// update the service container environment
 	err := service.Environment(ctn, c.build, c.repo, _service)
@@ -117,13 +118,7 @@ func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) er
 	_service, err := service.Load(ctn, &c.services)
 	if err != nil {
 		// create the service from the container
-		_service = new(library.Service)
-		_service.SetName(ctn.Name)
-		_service.SetNumber(ctn.Number)
-		_service.SetStatus(constants.StatusPending)
-		_service.SetHost(ctn.Environment["VELA_HOST"])
-		_service.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-		_service.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+		_service = library.ServiceFromContainer(ctn)
 	}
 
 	// defer taking a snapshot of the service

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -15,16 +15,22 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
+// create a stage logging pattern.
+const stagePattern = "[stage: %s][step: %s]"
+
 // CreateStage prepares the stage for execution.
 func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
-	// create a step pattern for log output
-	_pattern := fmt.Sprintf(stepPattern, c.init.Name)
+	// create a stage pattern for log output
+	_pattern := fmt.Sprintf(stagePattern, c.init.Name, c.init.Name)
 
 	// output init progress to stdout
 	fmt.Fprintln(os.Stdout, _pattern, "> Pulling step images for stage", s.Name, "...")
 
 	// create the steps for the stage
 	for _, _step := range s.Steps {
+		// update the container environment with stage name
+		_step.Environment["VELA_STEP_STAGE"] = s.Name
+
 		// create the step
 		err := c.CreateStep(ctx, _step)
 		if err != nil {

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -131,6 +131,13 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 	// create a step pattern for log output
 	_pattern := fmt.Sprintf(stepPattern, ctn.Name)
 
+	// check if the container provided is for stages
+	_stage, ok := ctn.Environment["VELA_STEP_STAGE"]
+	if ok {
+		// create a stage pattern for log output
+		_pattern = fmt.Sprintf(stagePattern, _stage, ctn.Name)
+	}
+
 	// create new scanner from the container output
 	scanner := bufio.NewScanner(rc)
 

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -50,15 +50,17 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 
 // PlanStep prepares the step for execution.
 func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
-	// update the engine step object
+	// create the library step object
 	_step := new(library.Step)
 	_step.SetName(ctn.Name)
 	_step.SetNumber(ctn.Number)
+	_step.SetImage(ctn.Image)
+	_step.SetStage(ctn.Environment["VELA_STEP_STAGE"])
 	_step.SetStatus(constants.StatusRunning)
 	_step.SetStarted(time.Now().UTC().Unix())
-	_step.SetHost(ctn.Environment["VELA_HOST"])
-	_step.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-	_step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+	_step.SetHost(c.build.GetHost())
+	_step.SetRuntime(c.build.GetRuntime())
+	_step.SetDistribution(c.build.GetDistribution())
 
 	// update the step container environment
 	err := step.Environment(ctn, c.build, c.repo, _step)
@@ -161,13 +163,7 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 	_step, err := step.Load(ctn, &c.steps)
 	if err != nil {
 		// create the step from the container
-		_step = new(library.Step)
-		_step.SetName(ctn.Name)
-		_step.SetNumber(ctn.Number)
-		_step.SetStatus(constants.StatusPending)
-		_step.SetHost(ctn.Environment["VELA_HOST"])
-		_step.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-		_step.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+		_step = library.StepFromContainer(ctn)
 	}
 
 	// defer taking a snapshot of the step


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This ensures that as the logs are output to `stdout` for the `local` executor, the stage name is also recorded in those logs.

Previously, when running a stages pipeline with the `local` executor, we'd get output like:

```
$ vela exec pipeline --path action/pipeline/testdata --file stages_default.yml
[step: init] > Inspecting runtime network...
[step: init] $ docker network inspect localOrg_localRepo_1
...
```

Now, we get output that looks like this:

```
$ vela exec pipeline --path action/pipeline/testdata --file stages_default.yml
[stage: init][step: init] > Inspecting runtime network...
[stage: init][step: init] $ docker network inspect localOrg_localRepo_1
...
```

I also updated the way we capture service and step information from the client.