### PR TITLE
feat(internal): add build.Upload() function

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -360,35 +359,8 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 // ExecBuild runs a pipeline for a build.
 func (c *client) ExecBuild(ctx context.Context) error {
-	defer func() {
-		// Overwrite with proper status and error only if build was not canceled
-		if !strings.EqualFold(c.build.GetStatus(), constants.StatusCanceled) {
-			// NOTE: if the build is already in a failure state we do not
-			// want to update the state to be success
-			if !strings.EqualFold(c.build.GetStatus(), constants.StatusFailure) {
-				c.build.SetStatus(constants.StatusSuccess)
-			}
-
-			// NOTE: When an error occurs during a build that does not have to do
-			// with a pipeline we should set build status to "error" not "failed"
-			// because it is worker related and not build.
-			if c.err != nil {
-				c.build.SetError(c.err.Error())
-				c.build.SetStatus(constants.StatusError)
-			}
-		}
-		// update the build fields
-		c.build.SetFinished(time.Now().UTC().Unix())
-
-		c.logger.Info("uploading build state")
-		// send API call to update the build
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#BuildService.Update
-		_, _, err := c.Vela.Build.Update(c.repo.GetOrg(), c.repo.GetName(), c.build)
-		if err != nil {
-			c.logger.Errorf("unable to upload build state: %v", err)
-		}
-	}()
+	// defer an upload of the build
+	defer build.Upload(c.build, c.Vela, c.err, c.logger, c.repo)
 
 	// execute the services for the pipeline
 	for _, _service := range c.pipeline.Services {

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -358,6 +358,8 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 }
 
 // ExecBuild runs a pipeline for a build.
+//
+// nolint: funlen // ignore function length due to comments and log messages
 func (c *client) ExecBuild(ctx context.Context) error {
 	// defer an upload of the build
 	defer build.Upload(c.build, c.Vela, c.err, c.logger, c.repo)

--- a/internal/build/upload.go
+++ b/internal/build/upload.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package build
+
+import (
+	"time"
+
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+	"github.com/sirupsen/logrus"
+)
+
+// Upload tracks the final state of the build
+// and attempts to upload it to the server.
+func Upload(b *library.Build, c *vela.Client, e error, l *logrus.Entry, r *library.Repo) {
+	// handle the build based off the status provided
+	switch b.GetStatus() {
+	// build is in a canceled state
+	case constants.StatusCanceled:
+		fallthrough
+	// build is in a error state
+	case constants.StatusError:
+		fallthrough
+	// build is in a failure state
+	case constants.StatusFailure:
+		// if the build is in a canceled, error
+		// or failure state we DO NOT want to
+		// update the state to be success
+		break
+	// build is in a pending state
+	case constants.StatusPending:
+		// if the build is in a pending state
+		// then something must have gone
+		// drastically wrong because this
+		// SHOULD NOT happen
+		b.SetStatus(constants.StatusKilled)
+	default:
+		// update the build with a success state
+		b.SetStatus(constants.StatusSuccess)
+	}
+
+	// check if the error provided is empty
+	if e != nil {
+		// update the build  with error based values
+		b.SetError(e.Error())
+		b.SetStatus(constants.StatusError)
+	}
+
+	// update the build with the finished timestamp
+	b.SetFinished(time.Now().UTC().Unix())
+
+	// check if the logger provided is empty
+	if l == nil {
+		l = logrus.NewEntry(logrus.StandardLogger())
+	}
+
+	// check if the Vela client provided is empty
+	if c != nil {
+		l.Debug("uploading final build state")
+
+		// send API call to update the build
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#BuildService.Update
+		_, _, err := c.Build.Update(r.GetOrg(), r.GetName(), b)
+		if err != nil {
+			l.Errorf("unable to upload final build state: %v", err)
+		}
+	}
+}

--- a/internal/build/upload_test.go
+++ b/internal/build/upload_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package build
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/mock/server"
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/library"
+)
+
+func TestBuild_Upload(t *testing.T) {
+	// setup types
+	_build := &library.Build{
+		ID:           vela.Int64(1),
+		Number:       vela.Int(1),
+		Parent:       vela.Int(1),
+		Event:        vela.String("push"),
+		Status:       vela.String("success"),
+		Error:        vela.String(""),
+		Enqueued:     vela.Int64(1563474077),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(1563474077),
+		Finished:     vela.Int64(0),
+		Deploy:       vela.String(""),
+		Clone:        vela.String("https://github.com/github/octocat.git"),
+		Source:       vela.String("https://github.com/github/octocat/abcdefghi123456789"),
+		Title:        vela.String("push received from https://github.com/github/octocat"),
+		Message:      vela.String("First commit..."),
+		Commit:       vela.String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Sender:       vela.String("OctoKitty"),
+		Author:       vela.String("OctoKitty"),
+		Branch:       vela.String("master"),
+		Ref:          vela.String("refs/heads/master"),
+		BaseRef:      vela.String(""),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	_canceled := *_build
+	_canceled.SetStatus("canceled")
+
+	_error := *_build
+	_error.SetStatus("error")
+
+	_pending := *_build
+	_pending.SetStatus("pending")
+
+	_repo := &library.Repo{
+		ID:          vela.Int64(1),
+		Org:         vela.String("github"),
+		Name:        vela.String("octocat"),
+		FullName:    vela.String("github/octocat"),
+		Link:        vela.String("https://github.com/github/octocat"),
+		Clone:       vela.String("https://github.com/github/octocat.git"),
+		Branch:      vela.String("master"),
+		Timeout:     vela.Int64(60),
+		Visibility:  vela.String("public"),
+		Private:     vela.Bool(false),
+		Trusted:     vela.Bool(false),
+		Active:      vela.Bool(true),
+		AllowPull:   vela.Bool(false),
+		AllowPush:   vela.Bool(true),
+		AllowDeploy: vela.Bool(false),
+		AllowTag:    vela.Bool(false),
+	}
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, "", nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	tests := []struct {
+		build  *library.Build
+		client *vela.Client
+		err    error
+		repo   *library.Repo
+	}{
+		{
+			build:  _build,
+			client: _client,
+			err:    errors.New("unable to create network"),
+			repo:   _repo,
+		},
+		{
+			build:  &_canceled,
+			client: _client,
+			err:    errors.New("unable to create network"),
+			repo:   _repo,
+		},
+		{
+			build:  &_error,
+			client: _client,
+			err:    errors.New("unable to create network"),
+			repo:   _repo,
+		},
+		{
+			build:  &_pending,
+			client: _client,
+			err:    errors.New("unable to create network"),
+			repo:   _repo,
+		},
+		{
+			build:  nil,
+			client: _client,
+			err:    errors.New("unable to create network"),
+			repo:   _repo,
+		},
+		{
+			build:  nil,
+			client: nil,
+			err:    nil,
+			repo:   nil,
+		},
+	}
+
+	// run test
+	for _, test := range tests {
+		Upload(test.build, test.client, test.err, nil, test.repo)
+	}
+}


### PR DESCRIPTION
This adds a new `build.Upload()` function to the `go-vela/pkg-executor/internal/build` package.

The intention of this function is to track the final state of the build and upload it to Vela.

This benefits us by reducing the non-test LOC in the executor codebase:

https://github.com/go-vela/pkg-executor/blob/e93ba33c7f6ab785fa56f7ae565a8addc56644d5/internal/build/upload.go#L16-L72