### PR TITLE
refactor: service.Snapshot() -> service.Upload()

### DIFF
--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -242,8 +242,8 @@ func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) er
 		_service = library.ServiceFromContainer(ctn)
 	}
 
-	// defer taking a snapshot of the service
-	defer service.Snapshot(ctn, c.build, c.Vela, logger, c.repo, _service)
+	// defer an upload of the service
+	defer service.Upload(ctn, c.build, c.Vela, logger, c.repo, _service)
 
 	logger.Debug("inspecting container")
 	// inspect the runtime container

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -121,8 +121,8 @@ func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) er
 		_service = library.ServiceFromContainer(ctn)
 	}
 
-	// defer taking a snapshot of the service
-	defer service.Snapshot(ctn, c.build, nil, nil, nil, _service)
+	// defer an upload of the service
+	defer service.Upload(ctn, c.build, nil, nil, nil, _service)
 
 	// inspect the runtime container
 	err = c.Runtime.InspectContainer(ctx, ctn)

--- a/internal/service/upload_test.go
+++ b/internal/service/upload_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
-func TestService_Snapshot(t *testing.T) {
+func TestService_Upload(t *testing.T) {
 	// setup types
 	_build := &library.Build{
 		ID:           vela.Int64(1),
@@ -91,7 +91,7 @@ func TestService_Snapshot(t *testing.T) {
 		Number:       vela.Int(1),
 		Name:         vela.String("postgres"),
 		Image:        vela.String("postgres:12-alpine"),
-		Status:       vela.String("pending"),
+		Status:       vela.String("running"),
 		ExitCode:     vela.Int(0),
 		Created:      vela.Int64(1563474076),
 		Started:      vela.Int64(0),
@@ -100,6 +100,15 @@ func TestService_Snapshot(t *testing.T) {
 		Runtime:      vela.String("docker"),
 		Distribution: vela.String("linux"),
 	}
+
+	_canceled := *_service
+	_canceled.SetStatus("canceled")
+
+	_error := *_service
+	_error.SetStatus("error")
+
+	_pending := *_service
+	_pending.SetStatus("pending")
 
 	gin.SetMode(gin.TestMode)
 
@@ -127,6 +136,27 @@ func TestService_Snapshot(t *testing.T) {
 		{
 			build:     _build,
 			client:    _client,
+			container: _container,
+			repo:      _repo,
+			service:   &_canceled,
+		},
+		{
+			build:     _build,
+			client:    _client,
+			container: _container,
+			repo:      _repo,
+			service:   &_error,
+		},
+		{
+			build:     _build,
+			client:    _client,
+			container: _container,
+			repo:      _repo,
+			service:   &_pending,
+		},
+		{
+			build:     _build,
+			client:    _client,
 			container: _exitCode,
 			repo:      _repo,
 			service:   nil,
@@ -135,6 +165,6 @@ func TestService_Snapshot(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		Snapshot(test.container, test.build, test.client, nil, test.repo, test.service)
+		Upload(test.container, test.build, test.client, nil, test.repo, test.service)
 	}
 }


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This refactors the `service.Snapshot()` function to `service.Upload()` for the `go-vela/pkg-executor/internal/service` package.

The `service.Snapshot()` function was already tracking the final state of the service and uploading it to Vela.

Renaming it to `service.Upload()` will keep it in sync with the `internal/build` package and follow the upload pattern.

A `service.Snapshot()` function will be added in a subsequent PR that fits better with the snapshot pattern.

https://github.com/go-vela/pkg-executor/blob/67d59a9a841dde61d8a52d101440187e6bbdce66/internal/service/upload.go#L17-L88