### PR TITLE
feat(executor): enable setting executor version

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -49,6 +49,7 @@ func TestExecutor_New(t *testing.T) {
 		linux.WithRuntime(_runtime),
 		linux.WithUser(_user),
 		linux.WithVelaClient(_client),
+		linux.WithVersion("v1.0.0"),
 	)
 	if err != nil {
 		t.Errorf("unable to create linux engine: %v", err)
@@ -62,6 +63,7 @@ func TestExecutor_New(t *testing.T) {
 		local.WithRuntime(_runtime),
 		local.WithUser(_user),
 		local.WithVelaClient(_client),
+		local.WithVersion("v1.0.0"),
 	)
 	if err != nil {
 		t.Errorf("unable to create local engine: %v", err)
@@ -83,6 +85,7 @@ func TestExecutor_New(t *testing.T) {
 				Repo:     _repo,
 				Runtime:  _runtime,
 				User:     _user,
+				Version:  "v1.0.0",
 			},
 			want: nil,
 		},
@@ -96,6 +99,7 @@ func TestExecutor_New(t *testing.T) {
 				Repo:     _repo,
 				Runtime:  _runtime,
 				User:     _user,
+				Version:  "v1.0.0",
 			},
 			want: _linux,
 		},
@@ -109,6 +113,7 @@ func TestExecutor_New(t *testing.T) {
 				Repo:     _repo,
 				Runtime:  _runtime,
 				User:     _user,
+				Version:  "v1.0.0",
 			},
 			want: _local,
 		},
@@ -122,6 +127,7 @@ func TestExecutor_New(t *testing.T) {
 				Repo:     _repo,
 				Runtime:  _runtime,
 				User:     _user,
+				Version:  "v1.0.0",
 			},
 			want: nil,
 		},
@@ -135,6 +141,7 @@ func TestExecutor_New(t *testing.T) {
 				Repo:     _repo,
 				Runtime:  _runtime,
 				User:     _user,
+				Version:  "v1.0.0",
 			},
 			want: nil,
 		},
@@ -148,6 +155,7 @@ func TestExecutor_New(t *testing.T) {
 				Repo:     _repo,
 				Runtime:  _runtime,
 				User:     _user,
+				Version:  "v1.0.0",
 			},
 			want: nil,
 		},

--- a/executor/linux/linux.go
+++ b/executor/linux/linux.go
@@ -24,6 +24,7 @@ type (
 		Runtime  runtime.Engine
 		Secrets  map[string]*library.Secret
 		Hostname string
+		Version  string
 
 		// clients for build actions
 		secret *secretSvc

--- a/executor/linux/opts.go
+++ b/executor/linux/opts.go
@@ -159,3 +159,21 @@ func WithVelaClient(cli *vela.Client) Opt {
 		return nil
 	}
 }
+
+// WithVersion sets the version in the client.
+func WithVersion(version string) Opt {
+	logrus.Trace("configuring version in linux client")
+
+	return func(c *client) error {
+		// check if a version is provided
+		if len(version) == 0 {
+			// default the version to localhost
+			version = "v0.0.0"
+		}
+
+		// set the version in the client
+		c.Version = version
+
+		return nil
+	}
+}

--- a/executor/linux/opts_test.go
+++ b/executor/linux/opts_test.go
@@ -320,3 +320,34 @@ func TestLinux_Opt_WithVelaClient(t *testing.T) {
 		}
 	}
 }
+
+func TestLinux_Opt_WithVersion(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{
+			version: "v1.0.0",
+			want:    "v1.0.0",
+		},
+		{
+			version: "",
+			want:    "v0.0.0",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithVersion(test.version),
+		)
+		if err != nil {
+			t.Errorf("unable to create linux engine: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.Version, test.want) {
+			t.Errorf("WithVersion is %v, want %v", _engine.Version, test.want)
+		}
+	}
+}

--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -45,9 +45,7 @@ func (s *secretSvc) create(ctx context.Context, ctn *pipeline.Container) error {
 	ctn.Environment["BUILD_HOST"] = s.client.build.GetHost()
 	ctn.Environment["VELA_HOST"] = s.client.build.GetHost()
 	ctn.Environment["VELA_RUNTIME"] = s.client.build.GetRuntime()
-
-	// TODO: remove hardcoded reference
-	ctn.Environment["VELA_VERSION"] = "v0.7.0"
+	ctn.Environment["VELA_VERSION"] = s.client.Version
 
 	logger.Debug("setting up container")
 	// setup the runtime container

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -33,7 +33,7 @@ func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) err
 	}
 
 	// update the service container environment
-	err = service.Environment(ctn, c.build, c.repo, nil)
+	err = service.Environment(ctn, c.build, c.repo, nil, c.Version)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error
 	}
 
 	// update the service container environment
-	err = service.Environment(ctn, c.build, c.repo, _service)
+	err = service.Environment(ctn, c.build, c.repo, _service, c.Version)
 	if err != nil {
 		return err
 	}

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -38,7 +38,7 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 	}
 
 	// update the step container environment
-	err = step.Environment(ctn, c.build, c.repo, nil)
+	err = step.Environment(ctn, c.build, c.repo, nil, c.Version)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	}
 
 	// update the step container environment
-	err = step.Environment(ctn, c.build, c.repo, _step)
+	err = step.Environment(ctn, c.build, c.repo, _step, c.Version)
 	if err != nil {
 		return err
 	}

--- a/executor/local/local.go
+++ b/executor/local/local.go
@@ -19,6 +19,7 @@ type (
 		Vela     *vela.Client
 		Runtime  runtime.Engine
 		Hostname string
+		Version  string
 
 		// private fields
 		init     *pipeline.Container

--- a/executor/local/opts.go
+++ b/executor/local/opts.go
@@ -103,3 +103,19 @@ func WithVelaClient(cli *vela.Client) Opt {
 		return nil
 	}
 }
+
+// WithVersion sets the version in the client.
+func WithVersion(version string) Opt {
+	return func(c *client) error {
+		// check if a version is provided
+		if len(version) == 0 {
+			// default the version
+			version = "v0.0.0"
+		}
+
+		// set the version in the client
+		c.Version = version
+
+		return nil
+	}
+}

--- a/executor/local/opts_test.go
+++ b/executor/local/opts_test.go
@@ -73,7 +73,7 @@ func TestLocal_Opt_WithHostname(t *testing.T) {
 			WithHostname(test.hostname),
 		)
 		if err != nil {
-			t.Errorf("unable to create Local engine: %v", err)
+			t.Errorf("unable to create local engine: %v", err)
 		}
 
 		if !reflect.DeepEqual(_engine.Hostname, test.want) {
@@ -261,6 +261,37 @@ func TestLocal_Opt_WithVelaClient(t *testing.T) {
 
 		if !reflect.DeepEqual(_engine.Vela, _client) {
 			t.Errorf("WithVelaClient is %v, want %v", _engine.Vela, _client)
+		}
+	}
+}
+
+func TestLocal_Opt_WithVersion(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{
+			version: "v1.0.0",
+			want:    "v1.0.0",
+		},
+		{
+			version: "",
+			want:    "v0.0.0",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithVersion(test.version),
+		)
+		if err != nil {
+			t.Errorf("unable to create local engine: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.Version, test.want) {
+			t.Errorf("WithVersion is %v, want %v", _engine.Version, test.want)
 		}
 	}
 }

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -30,7 +30,7 @@ func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) err
 	}
 
 	// update the service container environment
-	err = service.Environment(ctn, c.build, c.repo, nil)
+	err = service.Environment(ctn, c.build, c.repo, nil, c.Version)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (c *client) PlanService(ctx context.Context, ctn *pipeline.Container) error
 	_service.SetDistribution(c.build.GetDistribution())
 
 	// update the service container environment
-	err := service.Environment(ctn, c.build, c.repo, _service)
+	err := service.Environment(ctn, c.build, c.repo, _service, c.Version)
 	if err != nil {
 		return err
 	}

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -34,7 +34,7 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 	}
 
 	// update the step container environment
-	err = step.Environment(ctn, c.build, c.repo, nil)
+	err = step.Environment(ctn, c.build, c.repo, nil, c.Version)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	_step.SetDistribution(c.build.GetDistribution())
 
 	// update the step container environment
-	err := step.Environment(ctn, c.build, c.repo, _step)
+	err := step.Environment(ctn, c.build, c.repo, _step, c.Version)
 	if err != nil {
 		return err
 	}

--- a/executor/setup.go
+++ b/executor/setup.go
@@ -32,6 +32,8 @@ type Setup struct {
 	Driver string
 	// specifies the executor hostname
 	Hostname string
+	// specifies the executor version
+	Version string
 	// API client for sending requests to Vela
 	Client *vela.Client
 	// engine used for creating runtime resources
@@ -73,6 +75,7 @@ func (s *Setup) Linux() (Engine, error) {
 		linux.WithRuntime(s.Runtime),
 		linux.WithUser(s.User),
 		linux.WithVelaClient(s.Client),
+		linux.WithVersion(s.Version),
 	)
 }
 
@@ -92,6 +95,7 @@ func (s *Setup) Local() (Engine, error) {
 		local.WithRuntime(s.Runtime),
 		local.WithUser(s.User),
 		local.WithVelaClient(s.Client),
+		local.WithVersion(s.Version),
 	)
 }
 

--- a/executor/setup_test.go
+++ b/executor/setup_test.go
@@ -83,6 +83,7 @@ func TestExecutor_Setup_Linux(t *testing.T) {
 		linux.WithRuntime(_runtime),
 		linux.WithUser(_user),
 		linux.WithVelaClient(_client),
+		linux.WithVersion("v1.0.0"),
 	)
 	if err != nil {
 		t.Errorf("unable to create linux engine: %v", err)
@@ -92,10 +93,12 @@ func TestExecutor_Setup_Linux(t *testing.T) {
 		Build:    _build,
 		Client:   _client,
 		Driver:   constants.DriverLinux,
+		Hostname: "localhost",
 		Pipeline: _pipeline,
 		Repo:     _repo,
 		Runtime:  _runtime,
 		User:     _user,
+		Version:  "v1.0.0",
 	}
 
 	// run test
@@ -133,6 +136,7 @@ func TestExecutor_Setup_Local(t *testing.T) {
 		local.WithRuntime(_runtime),
 		local.WithUser(_user),
 		local.WithVelaClient(_client),
+		local.WithVersion("v1.0.0"),
 	)
 	if err != nil {
 		t.Errorf("unable to create local engine: %v", err)
@@ -142,10 +146,12 @@ func TestExecutor_Setup_Local(t *testing.T) {
 		Build:    _build,
 		Client:   _client,
 		Driver:   "local",
+		Hostname: "localhost",
 		Pipeline: _pipeline,
 		Repo:     _repo,
 		Runtime:  _runtime,
 		User:     _user,
+		Version:  "v1.0.0",
 	}
 
 	// run test

--- a/internal/service/environment.go
+++ b/internal/service/environment.go
@@ -14,7 +14,7 @@ import (
 
 // Environment attempts to update the environment variables
 // for the container based off the library resources.
-func Environment(c *pipeline.Container, b *library.Build, r *library.Repo, s *library.Service) error {
+func Environment(c *pipeline.Container, b *library.Build, r *library.Repo, s *library.Service, version string) error {
 	// check if container or container environment are empty
 	if c == nil || c.Environment == nil {
 		return fmt.Errorf("empty container provided for environment")
@@ -33,18 +33,14 @@ func Environment(c *pipeline.Container, b *library.Build, r *library.Repo, s *li
 		workspace, ok := c.Environment["VELA_WORKSPACE"]
 		if !ok {
 			// set default for workspace
-			//
-			// TODO: consider making this a constant
-			workspace = "/vela"
+			workspace = constants.WorkspaceDefault
 		}
 
 		// update environment variables
 		c.Environment["VELA_DISTRIBUTION"] = b.GetDistribution()
 		c.Environment["VELA_HOST"] = b.GetHost()
 		c.Environment["VELA_RUNTIME"] = b.GetRuntime()
-
-		// TODO: remove hardcoded reference
-		c.Environment["VELA_VERSION"] = "v0.7.0"
+		c.Environment["VELA_VERSION"] = version
 
 		// populate environment variables from build library
 		c.Environment = appendMap(c.Environment, b.Environment(workspace, channel))

--- a/internal/service/environment_test.go
+++ b/internal/service/environment_test.go
@@ -117,7 +117,7 @@ func TestService_Environment(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := Environment(test.container, test.build, test.repo, test.service)
+		err := Environment(test.container, test.build, test.repo, test.service, "v0.0.0")
 
 		if test.failure {
 			if err == nil {

--- a/internal/step/environment.go
+++ b/internal/step/environment.go
@@ -14,7 +14,7 @@ import (
 
 // Environment attempts to update the environment variables
 // for the container based off the library resources.
-func Environment(c *pipeline.Container, b *library.Build, r *library.Repo, s *library.Step) error {
+func Environment(c *pipeline.Container, b *library.Build, r *library.Repo, s *library.Step, version string) error {
 	// check if container or container environment are empty
 	if c == nil || c.Environment == nil {
 		return fmt.Errorf("empty container provided for environment")
@@ -33,18 +33,14 @@ func Environment(c *pipeline.Container, b *library.Build, r *library.Repo, s *li
 		workspace, ok := c.Environment["VELA_WORKSPACE"]
 		if !ok {
 			// set default for workspace
-			//
-			// TODO: consider making this a constant
-			workspace = "/vela"
+			workspace = constants.WorkspaceDefault
 		}
 
 		// update environment variables
 		c.Environment["VELA_DISTRIBUTION"] = b.GetDistribution()
 		c.Environment["VELA_HOST"] = b.GetHost()
 		c.Environment["VELA_RUNTIME"] = b.GetRuntime()
-
-		// TODO: remove hardcoded reference
-		c.Environment["VELA_VERSION"] = "v0.7.0"
+		c.Environment["VELA_VERSION"] = version
 
 		// populate environment variables from build library
 		c.Environment = appendMap(c.Environment, b.Environment(workspace, channel))

--- a/internal/step/environment_test.go
+++ b/internal/step/environment_test.go
@@ -116,7 +116,7 @@ func TestStep_Environment(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := Environment(test.container, test.build, test.repo, test.step)
+		err := Environment(test.container, test.build, test.repo, test.step, "v0.0.0")
 
 		if test.failure {
 			if err == nil {


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This allows us to pass a version to the executor clients so we no longer have to hardcode these values.

Currently we have code that looks like this:

https://github.com/go-vela/pkg-executor/blob/e5c5b0b461bb681bbd47e39c8276d9f6ad275399/internal/service/environment.go#L46-L47

https://github.com/go-vela/pkg-executor/blob/e5c5b0b461bb681bbd47e39c8276d9f6ad275399/internal/step/environment.go#L46-L47

https://github.com/go-vela/pkg-executor/blob/e5c5b0b461bb681bbd47e39c8276d9f6ad275399/executor/linux/secret.go#L49-L50

The problem with this is we are left responsible to update the code when any new release is created allowing for the potential of having inaccurate information in the codebase if the code is not updated.

By allowing us to pass the version to the client, we no longer have this potential and create a better experience for all.

It is worth mentioning that if no version is provided, we set a "default":

https://github.com/go-vela/pkg-executor/blob/e291ad52e06dfe587d772c142dafba435878894d/executor/linux/opts.go#L168-L172

https://github.com/go-vela/pkg-executor/blob/e291ad52e06dfe587d772c142dafba435878894d/executor/local/opts.go#L110-L114