### PR TITLE
feat(internal): add step.Snapshot() function v2

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -406,35 +406,6 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		if c.err != nil {
 			return fmt.Errorf("unable to execute step: %w", c.err)
 		}
-
-		// load the step from the client
-		cStep, err := step.Load(_step, &c.steps)
-		if err != nil {
-			return err
-		}
-
-		// check the step exit code
-		if _step.ExitCode != 0 {
-			// check if we ignore step failures
-			if !_step.Ruleset.Continue {
-				// set build status to failure
-				c.build.SetStatus(constants.StatusFailure)
-			}
-
-			// update the step fields
-			cStep.SetExitCode(_step.ExitCode)
-			cStep.SetStatus(constants.StatusFailure)
-		}
-
-		cStep.SetFinished(time.Now().UTC().Unix())
-		c.logger.Infof("uploading %s step state", _step.Name)
-		// send API call to update the build
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, c.err = c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), cStep)
-		if c.err != nil {
-			return fmt.Errorf("unable to upload step state: %v", c.err)
-		}
 	}
 
 	// create an error group with the context for each stage

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -7,10 +7,8 @@ package linux
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-vela/pkg-executor/internal/step"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 )
 
@@ -124,36 +122,7 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 		// execute the step
 		err = c.ExecStep(ctx, _step)
 		if err != nil {
-			return err
-		}
-
-		// load the step from the client
-		cStep, err := step.Load(_step, &c.steps)
-		if err != nil {
-			return err
-		}
-
-		// check the step exit code
-		if _step.ExitCode != 0 {
-			// check if we ignore step failures
-			if !_step.Ruleset.Continue {
-				// set build status to failure
-				c.build.SetStatus(constants.StatusFailure)
-			}
-
-			// update the step fields
-			cStep.SetExitCode(_step.ExitCode)
-			cStep.SetStatus(constants.StatusFailure)
-		}
-
-		cStep.SetFinished(time.Now().UTC().Unix())
-		logger.Infof("uploading %s step state", _step.Name)
-		// send API call to update the build
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err = c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), cStep)
-		if err != nil {
-			return fmt.Errorf("unable to upload step state: %v", err)
+			return fmt.Errorf("unable to exec step %s: %w", _step.Name, err)
 		}
 	}
 

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -129,9 +129,18 @@ func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithField
 	logger := c.logger.WithField("step", ctn.Name)
 
+	// load the step from the client
+	_step, err := step.Load(ctn, &c.steps)
+	if err != nil {
+		return err
+	}
+
+	// defer taking a snapshot of the step
+	defer step.Snapshot(ctn, c.build, c.Vela, c.logger, c.repo, _step)
+
 	logger.Debug("running container")
 	// run the runtime container
-	err := c.Runtime.RunContainer(ctx, ctn, c.pipeline)
+	err = c.Runtime.RunContainer(ctx, ctn, c.pipeline)
 	if err != nil {
 		return err
 	}

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -247,28 +247,6 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		if c.err != nil {
 			return fmt.Errorf("unable to execute step: %w", c.err)
 		}
-
-		// load the init step from the client
-		s, err := step.Load(_step, &c.steps)
-		if err != nil {
-			c.err = err
-			return err
-		}
-
-		// check the step exit code
-		if _step.ExitCode != 0 {
-			// check if we ignore step failures
-			if !_step.Ruleset.Continue {
-				// set build status to failure
-				c.build.SetStatus(constants.StatusFailure)
-			}
-
-			// update the step fields
-			s.SetExitCode(_step.ExitCode)
-			s.SetStatus(constants.StatusFailure)
-		}
-
-		s.SetFinished(time.Now().UTC().Unix())
 	}
 
 	// create an error group with the context for each stage

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -8,10 +8,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/go-vela/pkg-executor/internal/step"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 )
 
@@ -99,27 +97,6 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 		if err != nil {
 			return fmt.Errorf("unable to exec step %s: %w", _step.Name, err)
 		}
-
-		// load the step from the client
-		cStep, err := step.Load(_step, &c.steps)
-		if err != nil {
-			return err
-		}
-
-		// check the step exit code
-		if _step.ExitCode != 0 {
-			// check if we ignore step failures
-			if !_step.Ruleset.Continue {
-				// set build status to failure
-				c.build.SetStatus(constants.StatusFailure)
-			}
-
-			// update the step fields
-			cStep.SetExitCode(_step.ExitCode)
-			cStep.SetStatus(constants.StatusFailure)
-		}
-
-		cStep.SetFinished(time.Now().UTC().Unix())
 	}
 
 	return nil

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -81,8 +81,17 @@ func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
 		return nil
 	}
 
+	// load the step from the client
+	_step, err := step.Load(ctn, &c.steps)
+	if err != nil {
+		return err
+	}
+
+	// defer taking a snapshot of the step
+	defer step.Snapshot(ctn, c.build, nil, nil, nil, _step)
+
 	// run the runtime container
-	err := c.Runtime.RunContainer(ctx, ctn, c.pipeline)
+	err = c.Runtime.RunContainer(ctx, ctn, c.pipeline)
 	if err != nil {
 		return err
 	}

--- a/internal/step/snapshot.go
+++ b/internal/step/snapshot.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package step
+
+import (
+	"time"
+
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+	"github.com/sirupsen/logrus"
+)
+
+// Snapshot creates a moment in time record of the
+// step and attempts to upload it to the server.
+func Snapshot(ctn *pipeline.Container, b *library.Build, c *vela.Client, l *logrus.Entry, r *library.Repo, s *library.Step) {
+	// check if the container is running in headless mode
+	if !ctn.Detach {
+		// update the step fields to indicate a success
+		s.SetStatus(constants.StatusSuccess)
+		s.SetFinished(time.Now().UTC().Unix())
+	}
+
+	// check if the container has an unsuccessful exit code
+	if ctn.ExitCode != 0 {
+		// check if container failures should be ignored
+		if !ctn.Ruleset.Continue {
+			// set build status to failure
+			b.SetStatus(constants.StatusFailure)
+		}
+
+		// update the step fields to indicate a failure
+		s.SetExitCode(ctn.ExitCode)
+		s.SetStatus(constants.StatusFailure)
+	}
+
+	// check if the logger provided is empty
+	if l == nil {
+		l = logrus.NewEntry(logrus.StandardLogger())
+	}
+
+	// check if the Vela client provided is empty
+	if c != nil {
+		l.Debug("uploading step snapshot")
+
+		// send API call to update the step
+		//
+		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
+		_, _, err := c.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+		if err != nil {
+			l.Errorf("unable to upload step snapshot: %v", err)
+		}
+	}
+}

--- a/internal/step/snapshot_test.go
+++ b/internal/step/snapshot_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package step
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/mock/server"
+	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/pipeline"
+)
+
+func TestStep_Snapshot(t *testing.T) {
+	// setup types
+	_build := &library.Build{
+		ID:           vela.Int64(1),
+		Number:       vela.Int(1),
+		Parent:       vela.Int(1),
+		Event:        vela.String("push"),
+		Status:       vela.String("success"),
+		Error:        vela.String(""),
+		Enqueued:     vela.Int64(1563474077),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(1563474077),
+		Finished:     vela.Int64(0),
+		Deploy:       vela.String(""),
+		Clone:        vela.String("https://github.com/github/octocat.git"),
+		Source:       vela.String("https://github.com/github/octocat/abcdefghi123456789"),
+		Title:        vela.String("push received from https://github.com/github/octocat"),
+		Message:      vela.String("First commit..."),
+		Commit:       vela.String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Sender:       vela.String("OctoKitty"),
+		Author:       vela.String("OctoKitty"),
+		Branch:       vela.String("master"),
+		Ref:          vela.String("refs/heads/master"),
+		BaseRef:      vela.String(""),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	_container := &pipeline.Container{
+		ID:          "step_github_octocat_1_init",
+		Directory:   "/home/github/octocat",
+		Environment: map[string]string{"FOO": "bar"},
+		Image:       "#init",
+		Name:        "init",
+		Number:      1,
+		Pull:        "always",
+	}
+
+	_exitCode := &pipeline.Container{
+		ID:          "step_github_octocat_1_init",
+		Directory:   "/home/github/octocat",
+		Environment: map[string]string{"FOO": "bar"},
+		ExitCode:    137,
+		Image:       "#init",
+		Name:        "init",
+		Number:      1,
+		Pull:        "always",
+	}
+
+	_repo := &library.Repo{
+		ID:          vela.Int64(1),
+		Org:         vela.String("github"),
+		Name:        vela.String("octocat"),
+		FullName:    vela.String("github/octocat"),
+		Link:        vela.String("https://github.com/github/octocat"),
+		Clone:       vela.String("https://github.com/github/octocat.git"),
+		Branch:      vela.String("master"),
+		Timeout:     vela.Int64(60),
+		Visibility:  vela.String("public"),
+		Private:     vela.Bool(false),
+		Trusted:     vela.Bool(false),
+		Active:      vela.Bool(true),
+		AllowPull:   vela.Bool(false),
+		AllowPush:   vela.Bool(true),
+		AllowDeploy: vela.Bool(false),
+		AllowTag:    vela.Bool(false),
+	}
+
+	_step := &library.Step{
+		ID:           vela.Int64(1),
+		BuildID:      vela.Int64(1),
+		RepoID:       vela.Int64(1),
+		Number:       vela.Int(1),
+		Name:         vela.String("clone"),
+		Image:        vela.String("target/vela-git:v0.3.0"),
+		Status:       vela.String("running"),
+		ExitCode:     vela.Int(0),
+		Created:      vela.Int64(1563474076),
+		Started:      vela.Int64(0),
+		Finished:     vela.Int64(1563474079),
+		Host:         vela.String("example.company.com"),
+		Runtime:      vela.String("docker"),
+		Distribution: vela.String("linux"),
+	}
+
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+
+	_client, err := vela.NewClient(s.URL, "", nil)
+	if err != nil {
+		t.Errorf("unable to create Vela API client: %v", err)
+	}
+
+	tests := []struct {
+		build     *library.Build
+		client    *vela.Client
+		container *pipeline.Container
+		repo      *library.Repo
+		step      *library.Step
+	}{
+		{
+			build:     _build,
+			client:    _client,
+			container: _container,
+			repo:      _repo,
+			step:      _step,
+		},
+		{
+			build:     _build,
+			client:    _client,
+			container: _exitCode,
+			repo:      _repo,
+			step:      nil,
+		},
+	}
+
+	// run test
+	for _, test := range tests {
+		Snapshot(test.container, test.build, test.client, nil, test.repo, test.step)
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

See https://github.com/go-vela/pkg-executor/pull/108 for reference

This adds a new `step.Snapshot()` function to the `go-vela/pkg-executor/internal/step` package.

The intention of this function is to create an instantaneous record of the step and upload it to Vela.

This benefits us by reducing the non-test LOC in the executor codebase:

https://github.com/go-vela/pkg-executor/blob/898c9d1d0bbf7d5e4fdbb3c8466a73e86f7e0863/internal/step/snapshot.go#L17-L57