### PR TITLE
refactor: use step.Upload() for the init step

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -217,18 +217,12 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		return err
 	}
 
+	// defer an upload of the init step
+	//
+	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#Upload
+	defer step.Upload(c.init, c.build, c.Vela, c.logger, c.repo, _init)
+
 	defer func() {
-		_init.SetFinished(time.Now().UTC().Unix())
-
-		c.logger.Infof("uploading %s step state", c.init.Name)
-		// send API call to update the step
-		//
-		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#StepService.Update
-		_, _, err := c.Vela.Step.Update(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), _init)
-		if err != nil {
-			c.logger.Errorf("unable to upload %s state: %v", c.init.Name, err)
-		}
-
 		c.logger.Infof("uploading %s step logs", c.init.Name)
 		// send API call to update the logs for the step
 		//

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -122,6 +122,11 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		return err
 	}
 
+	// defer an upload of the init step
+	//
+	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#Upload
+	defer step.Upload(c.init, c.build, nil, nil, nil, _init)
+
 	// create a step pattern for log output
 	_pattern := fmt.Sprintf(stepPattern, c.init.Name)
 
@@ -130,10 +135,6 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		// create a stage pattern for log output
 		_pattern = fmt.Sprintf(stagePattern, c.init.Name, c.init.Name)
 	}
-
-	defer func() {
-		_init.SetFinished(time.Now().UTC().Unix())
-	}()
 
 	// output init progress to stdout
 	fmt.Fprintln(os.Stdout, _pattern, "> Pulling service images...")


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This updates the logic in the `AssembleBuild()` function to use `step.Upload()`.

This allows us to adopt and follow the same pattern we use for tracking and uploading the state for the other steps.