### PR TITLE
test(local): overhaul test suite

### DIFF
--- a/executor/local/step_test.go
+++ b/executor/local/step_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 1011 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
@@ -6,18 +6,10 @@ package local
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
-
-	"github.com/gin-gonic/gin"
-
-	"github.com/go-vela/mock/server"
 
 	"github.com/go-vela/pkg-runtime/runtime/docker"
 
-	"github.com/go-vela/sdk-go/vela"
-
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
 )
@@ -27,16 +19,6 @@ func TestLocal_CreateStep(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps()
-
-	gin.SetMode(gin.TestMode)
-
-	s := httptest.NewServer(server.FakeHandler())
-
-	_client, err := vela.NewClient(s.URL, "", nil)
-	if err != nil {
-		t.Errorf("unable to create Vela API client: %v", err)
-	}
 
 	_runtime, err := docker.NewMock()
 	if err != nil {
@@ -48,41 +30,45 @@ func TestLocal_CreateStep(t *testing.T) {
 		failure   bool
 		container *pipeline.Container
 	}{
-		{
+		{ // init step container
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "#init",
 				Name:        "init",
 				Number:      1,
-				Pull:        "always",
+				Pull:        "not_present",
 			},
 		},
-		{
+		{ // basic step container
 			failure: false,
 			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
+				ID:          "step_github_octocat_1_echo",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "clone",
-				Number:      2,
-				Pull:        "always",
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
 			},
 		},
-		{
+		{ // step container with image not found
 			failure: true,
 			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
+				ID:          "step_github_octocat_1_echo",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:notfound",
-				Name:        "clone",
-				Number:      2,
-				Pull:        "always",
+				Image:       "alpine:notfound",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
 			},
+		},
+		{ // empty step container
+			failure:   true,
+			container: new(pipeline.Container),
 		},
 	}
 
@@ -90,11 +76,10 @@ func TestLocal_CreateStep(t *testing.T) {
 	for _, test := range tests {
 		_engine, err := New(
 			WithBuild(_build),
-			WithPipeline(_steps),
+			WithPipeline(new(pipeline.Build)),
 			WithRepo(_repo),
 			WithRuntime(_runtime),
 			WithUser(_user),
-			WithVelaClient(_client),
 		)
 		if err != nil {
 			t.Errorf("unable to create executor engine: %v", err)
@@ -121,16 +106,6 @@ func TestLocal_PlanStep(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps()
-
-	gin.SetMode(gin.TestMode)
-
-	s := httptest.NewServer(server.FakeHandler())
-
-	_client, err := vela.NewClient(s.URL, "", nil)
-	if err != nil {
-		t.Errorf("unable to create Vela API client: %v", err)
-	}
 
 	_runtime, err := docker.NewMock()
 	if err != nil {
@@ -142,17 +117,21 @@ func TestLocal_PlanStep(t *testing.T) {
 		failure   bool
 		container *pipeline.Container
 	}{
-		{
+		{ // basic step container
 			failure: false,
 			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
+				ID:          "step_github_octocat_1_echo",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "clone",
-				Number:      2,
-				Pull:        "always",
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
 			},
+		},
+		{ // empty step container
+			failure:   true,
+			container: new(pipeline.Container),
 		},
 	}
 
@@ -160,11 +139,10 @@ func TestLocal_PlanStep(t *testing.T) {
 	for _, test := range tests {
 		_engine, err := New(
 			WithBuild(_build),
-			WithPipeline(_steps),
+			WithPipeline(new(pipeline.Build)),
 			WithRepo(_repo),
 			WithRuntime(_runtime),
 			WithUser(_user),
-			WithVelaClient(_client),
 		)
 		if err != nil {
 			t.Errorf("unable to create executor engine: %v", err)
@@ -191,16 +169,6 @@ func TestLocal_ExecStep(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps()
-
-	gin.SetMode(gin.TestMode)
-
-	s := httptest.NewServer(server.FakeHandler())
-
-	_client, err := vela.NewClient(s.URL, "", nil)
-	if err != nil {
-		t.Errorf("unable to create Vela API client: %v", err)
-	}
 
 	_runtime, err := docker.NewMock()
 	if err != nil {
@@ -212,54 +180,58 @@ func TestLocal_ExecStep(t *testing.T) {
 		failure   bool
 		container *pipeline.Container
 	}{
-		{
+		{ // init step container
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "#init",
 				Name:        "init",
 				Number:      1,
-				Pull:        "always",
+				Pull:        "not_present",
 			},
 		},
-		{
+		{ // basic step container
 			failure: false,
 			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
+				ID:          "step_github_octocat_1_echo",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "clone",
-				Number:      2,
-				Pull:        "always",
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
 			},
 		},
-		{
+		{ // detached step container
 			failure: false,
 			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_clone",
+				ID:          "step_github_octocat_1_echo",
 				Detach:      true,
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "clone",
-				Number:      2,
-				Pull:        "always",
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
 			},
 		},
-		{
+		{ // step container with image not found
 			failure: true,
 			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_notfound",
-				Directory:   "/home/github/octocat",
+				ID:          "step_github_octocat_1_echo",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "notfound",
-				Number:      2,
-				Pull:        "always",
+				Image:       "alpine:notfound",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
 			},
+		},
+		{ // empty step container
+			failure:   true,
+			container: new(pipeline.Container),
 		},
 	}
 
@@ -267,22 +239,17 @@ func TestLocal_ExecStep(t *testing.T) {
 	for _, test := range tests {
 		_engine, err := New(
 			WithBuild(_build),
-			WithPipeline(_steps),
+			WithPipeline(new(pipeline.Build)),
 			WithRepo(_repo),
 			WithRuntime(_runtime),
 			WithUser(_user),
-			WithVelaClient(_client),
 		)
 		if err != nil {
 			t.Errorf("unable to create executor engine: %v", err)
 		}
 
-		_engine.steps.Store(test.container.ID, new(library.Step))
-
-		// create volume for runtime host config
-		err = _runtime.CreateVolume(context.Background(), _steps)
-		if err != nil {
-			t.Errorf("unable to create runtime volume: %w", err)
+		if !test.container.Empty() {
+			_engine.steps.Store(test.container.ID, new(library.Step))
 		}
 
 		err = _engine.ExecStep(context.Background(), test.container)
@@ -306,7 +273,6 @@ func TestLocal_StreamStep(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps()
 
 	_runtime, err := docker.NewMock()
 	if err != nil {
@@ -318,29 +284,33 @@ func TestLocal_StreamStep(t *testing.T) {
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // container step succeeds
+		{ // init step container
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
-				Directory:   "/vela/src/vcs.company.com/github/octocat",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "#init",
 				Name:        "init",
 				Number:      1,
-				Pull:        "always",
+				Pull:        "not_present",
 			},
 		},
-		{ // container step fails because of invalid container id
-			failure: true,
+		{ // basic step container
+			failure: false,
 			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_notfound",
-				Directory:   "/vela/src/vcs.company.com/github/octocat",
+				ID:          "step_github_octocat_1_echo",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "notfound",
-				Number:      2,
-				Pull:        "always",
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
 			},
+		},
+		{ // empty step container
+			failure:   true,
+			container: new(pipeline.Container),
 		},
 	}
 
@@ -348,7 +318,7 @@ func TestLocal_StreamStep(t *testing.T) {
 	for _, test := range tests {
 		_engine, err := New(
 			WithBuild(_build),
-			WithPipeline(_steps),
+			WithPipeline(new(pipeline.Build)),
 			WithRepo(_repo),
 			WithRuntime(_runtime),
 			WithUser(_user),
@@ -378,84 +348,40 @@ func TestLocal_DestroyStep(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps()
-
-	gin.SetMode(gin.TestMode)
-
-	s := httptest.NewServer(server.FakeHandler())
-
-	_client, err := vela.NewClient(s.URL, "", nil)
-	if err != nil {
-		t.Errorf("unable to create Vela API client: %v", err)
-	}
 
 	_runtime, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create runtime engine: %v", err)
 	}
 
-	_step := new(library.Step)
-	_step.SetName("clone")
-	_step.SetNumber(2)
-	_step.SetStatus(constants.StatusPending)
-
 	// setup tests
 	tests := []struct {
 		failure   bool
 		container *pipeline.Container
-		step      *library.Step
 	}{
-		{
+		{ // init step container
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
-				Directory:   "/home/github/octocat",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "#init",
 				Name:        "init",
 				Number:      1,
-				Pull:        "always",
+				Pull:        "not_present",
 			},
-			step: new(library.Step),
 		},
-		{
+		{ // basic step container
 			failure: false,
 			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
+				ID:          "step_github_octocat_1_echo",
+				Directory:   "/vela/src/github.com/github/octocat",
 				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "clone",
-				Number:      2,
-				Pull:        "always",
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
 			},
-			step: _step,
-		},
-		{
-			failure: true,
-			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_notfound",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "notfound",
-				Number:      2,
-				Pull:        "always",
-			},
-			step: new(library.Step),
-		},
-		{
-			failure: true,
-			container: &pipeline.Container{
-				ID:          "step_github_octocat_1_ignorenotfound",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "ignorenotfound",
-				Number:      2,
-				Pull:        "always",
-			},
-			step: new(library.Step),
 		},
 	}
 
@@ -463,17 +389,14 @@ func TestLocal_DestroyStep(t *testing.T) {
 	for _, test := range tests {
 		_engine, err := New(
 			WithBuild(_build),
-			WithPipeline(_steps),
+			WithPipeline(new(pipeline.Build)),
 			WithRepo(_repo),
 			WithRuntime(_runtime),
 			WithUser(_user),
-			WithVelaClient(_client),
 		)
 		if err != nil {
 			t.Errorf("unable to create executor engine: %v", err)
 		}
-
-		_engine.steps.Store(test.container.ID, test.step)
 
 		err = _engine.DestroyStep(context.Background(), test.container)
 


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This refactors the tests we have setup for the `go-vela/pkg-executor/executor/local` package.

The test coverage went from `87.4%` to `89.9%` and the time to execute went from ~ `16s` to ~ `6s`

You'll also note that the total number of LOC for the tests was cut in half.

These are the results of test coverage on the `master` branch:

```sh
 $ make test-cover

### Creating test coverage report
?   	github.com/go-vela/pkg-executor/cmd/vela-executor	[no test files]
ok  	github.com/go-vela/pkg-executor/executor	0.570s	coverage: 100.0% of statements
ok  	github.com/go-vela/pkg-executor/executor/linux	18.602s	coverage: 83.4% of statements
ok  	github.com/go-vela/pkg-executor/executor/local	15.998s	coverage: 87.4% of statements
?   	github.com/go-vela/pkg-executor/internal	[no test files]
ok  	github.com/go-vela/pkg-executor/internal/build	0.243s	coverage: 100.0% of statements
ok  	github.com/go-vela/pkg-executor/internal/service	0.360s	coverage: 100.0% of statements
ok  	github.com/go-vela/pkg-executor/internal/step	0.479s	coverage: 100.0% of statements

### Opening test coverage report
```

These are the results of test coverage on the `test/local/overhaul` branch:

```sh
$ make test-cover

### Creating test coverage report
?   	github.com/go-vela/pkg-executor/cmd/vela-executor	[no test files]
ok  	github.com/go-vela/pkg-executor/executor	0.550s	coverage: 100.0% of statements
ok  	github.com/go-vela/pkg-executor/executor/linux	16.053s	coverage: 83.4% of statements
ok  	github.com/go-vela/pkg-executor/executor/local	6.151s	coverage: 89.9% of statements
?   	github.com/go-vela/pkg-executor/internal	[no test files]
ok  	github.com/go-vela/pkg-executor/internal/build	0.618s	coverage: 100.0% of statements
ok  	github.com/go-vela/pkg-executor/internal/service	0.782s	coverage: 100.0% of statements
ok  	github.com/go-vela/pkg-executor/internal/step	0.392s	coverage: 100.0% of statements

### Opening test coverage report
```