### PR TITLE
fix(local): step output for stages

### DIFF
--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -155,8 +155,11 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 	// check if the container provided is for stages
 	_stage, ok := ctn.Environment["VELA_STEP_STAGE"]
 	if ok {
-		// create a stage pattern for log output
-		_pattern = fmt.Sprintf(stagePattern, _stage, ctn.Name)
+		// check if the stage name is set
+		if len(_stage) > 0 {
+			// create a stage pattern for log output
+			_pattern = fmt.Sprintf(stagePattern, _stage, ctn.Name)
+		}
 	}
 
 	// create new scanner from the container output

--- a/executor/local/step_test.go
+++ b/executor/local/step_test.go
@@ -308,6 +308,18 @@ func TestLocal_StreamStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
+		{ // basic stage container
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "github_octocat_1_echo_echo",
+				Directory:   "/vela/src/github.com/github/octocat",
+				Environment: map[string]string{"VELA_STEP_STAGE": "foo"},
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      1,
+				Pull:        "not_present",
+			},
+		},
 		{ // empty step container
 			failure:   true,
 			container: new(pipeline.Container),


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

I was playing around with the CLI locally trying to run pipelines on my workstation.

I noticed that when I was running certain pipelines that I would get the output for `stages` when I shouldn't be.

Here is the pipeline I was using:

```yaml
version: "1"

steps:
  - name: echo
    image: alpine:latest
    commands:
      - echo hello
```

Before this PR, the output looks like this:

```sh
[stage: ][step: echo] $ echo hello
[stage: ][step: echo] hello
```

Now, the output looks like this:

```sh
[step: echo] $ echo hello
[step: echo] hello
```