### PR TITLE
fix: wrap defers in function shell

### DIFF
--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -133,7 +133,7 @@ func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error
 	// defer taking a snapshot of the service
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/service#Snapshot
-	defer service.Snapshot(ctn, c.build, c.Vela, c.logger, c.repo, _service)
+	defer func() { service.Snapshot(ctn, c.build, c.Vela, c.logger, c.repo, _service) }()
 
 	logger.Debug("running container")
 	// run the runtime container
@@ -268,7 +268,7 @@ func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) er
 	// defer an upload of the service
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/service#LoaUploadd
-	defer service.Upload(ctn, c.build, c.Vela, logger, c.repo, _service)
+	defer func() { service.Upload(ctn, c.build, c.Vela, logger, c.repo, _service) }()
 
 	logger.Debug("inspecting container")
 	// inspect the runtime container

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -144,7 +144,7 @@ func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
 	// defer taking a snapshot of the step
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#Snapshot
-	defer step.Snapshot(ctn, c.build, c.Vela, c.logger, c.repo, _step)
+	defer func() { step.Snapshot(ctn, c.build, c.Vela, c.logger, c.repo, _step) }()
 
 	logger.Debug("running container")
 	// run the runtime container
@@ -308,7 +308,7 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 	// defer an upload of the step
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#Upload
-	defer step.Upload(ctn, c.build, c.Vela, logger, c.repo, _step)
+	defer func() { step.Upload(ctn, c.build, c.Vela, logger, c.repo, _step) }()
 
 	logger.Debug("inspecting container")
 	// inspect the runtime container

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -22,7 +22,7 @@ func (c *client) CreateBuild(ctx context.Context) error {
 	// defer taking a snapshot of the build
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/build#Snapshot
-	defer build.Snapshot(c.build, nil, c.err, nil, nil)
+	defer func() { build.Snapshot(c.build, nil, c.err, nil, nil) }()
 
 	// update the build fields
 	c.build.SetStatus(constants.StatusRunning)
@@ -54,7 +54,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	// defer taking a snapshot of the build
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/build#Snapshot
-	defer build.Snapshot(c.build, nil, c.err, nil, nil)
+	defer func() { build.Snapshot(c.build, nil, c.err, nil, nil) }()
 
 	// create a step pattern for log output
 	_pattern := fmt.Sprintf(stepPattern, c.init.Name)
@@ -112,7 +112,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	// defer taking a snapshot of the build
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/build#Snapshot
-	defer build.Snapshot(c.build, nil, c.err, nil, nil)
+	defer func() { build.Snapshot(c.build, nil, c.err, nil, nil) }()
 
 	// load the init step from the client
 	//
@@ -125,7 +125,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	// defer an upload of the init step
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#Upload
-	defer step.Upload(c.init, c.build, nil, nil, nil, _init)
+	defer func() { step.Upload(c.init, c.build, nil, nil, nil, _init) }()
 
 	// create a step pattern for log output
 	_pattern := fmt.Sprintf(stepPattern, c.init.Name)
@@ -216,7 +216,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	// defer an upload of the build
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/build#Upload
-	defer build.Upload(c.build, c.Vela, c.err, nil, nil)
+	defer func() { build.Upload(c.build, c.Vela, c.err, nil, nil) }()
 
 	// execute the services for the pipeline
 	for _, _service := range c.pipeline.Services {

--- a/executor/local/service.go
+++ b/executor/local/service.go
@@ -88,7 +88,7 @@ func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error
 	// defer taking a snapshot of the service
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/service#Snapshot
-	defer service.Snapshot(ctn, c.build, nil, nil, nil, _service)
+	defer func() { service.Snapshot(ctn, c.build, nil, nil, nil, _service) }()
 
 	// run the runtime container
 	err = c.Runtime.RunContainer(ctx, ctn, c.pipeline)
@@ -147,7 +147,7 @@ func (c *client) DestroyService(ctx context.Context, ctn *pipeline.Container) er
 	// defer an upload of the service
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/service#Upload
-	defer service.Upload(ctn, c.build, nil, nil, nil, _service)
+	defer func() { service.Upload(ctn, c.build, nil, nil, nil, _service) }()
 
 	// inspect the runtime container
 	err = c.Runtime.InspectContainer(ctx, ctn)

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -98,7 +98,7 @@ func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
 	// defer taking a snapshot of the step
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#Snapshot
-	defer step.Snapshot(ctn, c.build, nil, nil, nil, _step)
+	defer func() { step.Snapshot(ctn, c.build, nil, nil, nil, _step) }()
 
 	// run the runtime container
 	err = c.Runtime.RunContainer(ctx, ctn, c.pipeline)
@@ -192,7 +192,7 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 	// defer an upload of the step
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#Upload
-	defer step.Upload(ctn, c.build, nil, nil, nil, _step)
+	defer func() { step.Upload(ctn, c.build, nil, nil, nil, _step) }()
 
 	// inspect the runtime container
 	err = c.Runtime.InspectContainer(ctx, ctn)


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This fixes a bug with the manipulation of variables stored in the client that are passed to the `defer` calls.

Per https://golang.org/doc/effective_go.html#defer:

> The arguments to the deferred function (which include the receiver if the function is a method) are evaluated when the _defer_ executes, not when the _call_ executes. Besides avoiding worries about variables changing values as the function executes, this means that a single deferred call site can defer multiple function executions.

Due to the arguments for a deferred function being evaluated at the time the `defer` executes, this means that any manipulation of those variables after the `defer` are "ignored" for lack of a better term.

As an example, we pass the `error` stored in the client (`c.err`) to the `build.Snapshot()` and `build.Upload()` functions.

As we continue processing beyond the `defer` statements, if an error occurs we update `c.err` to ensure we're up-to-date.

The behavior experienced is that the error passed to `build.Snapshot()` and `build.Upload()` was always `nil`.

The reason for this is at the time we executed the `defer`, `c.err` was `nil` but was later updated after the `defer`.

This adds a `func()` shell around the logic in the `defer`, so the variables provided to the deferred function are evaluated **when the function call executes** rather than when the `defer` executes.