### PR TITLE
feat(internal): add step.LoadInit() function

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -40,8 +40,13 @@ func (c *client) CreateBuild(ctx context.Context) error {
 		return fmt.Errorf("unable to upload build state: %v", c.err)
 	}
 
-	// load the init container from the pipeline
-	c.init = c.loadInitContainer(c.pipeline)
+	// load the init step from the pipeline
+	//
+	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#LoadInit
+	c.init, c.err = step.LoadInit(c.pipeline)
+	if c.err != nil {
+		return fmt.Errorf("unable to load init step from pipeline: %w", c.err)
+	}
 
 	c.logger.Infof("creating %s step", c.init.Name)
 	// create the step

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -326,20 +326,3 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 
 	return nil
 }
-
-// loadInitContainer is a helper function to capture
-// the init step from the client.
-func (c *client) loadInitContainer(p *pipeline.Build) *pipeline.Container {
-	// TODO: make this better
-	init := new(pipeline.Container)
-	if len(p.Steps) > 0 {
-		init = p.Steps[0]
-	}
-
-	// TODO: make this better
-	if len(p.Stages) > 0 {
-		init = p.Stages[0].Steps[0]
-	}
-
-	return init
-}

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -31,8 +31,13 @@ func (c *client) CreateBuild(ctx context.Context) error {
 	c.build.SetDistribution(constants.DriverLocal)
 	c.build.SetRuntime(c.Runtime.Driver())
 
-	// load the init container from the pipeline
-	c.init = c.loadInitContainer(c.pipeline)
+	// load the init step from the pipeline
+	//
+	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/step#LoadInit
+	c.init, c.err = step.LoadInit(c.pipeline)
+	if c.err != nil {
+		return fmt.Errorf("unable to load init step from pipeline: %w", c.err)
+	}
 
 	// create the step
 	c.err = c.CreateStep(ctx, c.init)
@@ -216,7 +221,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	// defer an upload of the build
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-executor/internal/build#Upload
-	defer func() { build.Upload(c.build, c.Vela, c.err, nil, nil) }()
+	defer func() { build.Upload(c.build, nil, c.err, nil, nil) }()
 
 	// execute the services for the pipeline
 	for _, _service := range c.pipeline.Services {

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -211,20 +211,3 @@ func (c *client) DestroyStep(ctx context.Context, ctn *pipeline.Container) error
 
 	return nil
 }
-
-// loadInitContainer is a helper function to capture
-// the init step from the client.
-func (c *client) loadInitContainer(p *pipeline.Build) *pipeline.Container {
-	// TODO: make this better
-	init := new(pipeline.Container)
-	if len(p.Steps) > 0 {
-		init = p.Steps[0]
-	}
-
-	// TODO: make this better
-	if len(p.Stages) > 0 {
-		init = p.Stages[0].Steps[0]
-	}
-
-	return init
-}

--- a/internal/step/load.go
+++ b/internal/step/load.go
@@ -35,6 +35,32 @@ func Load(c *pipeline.Container, m *sync.Map) (*library.Step, error) {
 	return s, nil
 }
 
+// LoadInit attempts to capture the container representing
+// the init process from the pipeline.
+func LoadInit(p *pipeline.Build) (*pipeline.Container, error) {
+	// check if the pipeline provided is empty
+	if p == nil {
+		return nil, fmt.Errorf("empty pipeline provided")
+	}
+
+	// create new container for the init step
+	c := new(pipeline.Container)
+
+	// check if there are steps in the pipeline
+	if len(p.Steps) > 0 {
+		// update the container for the init process
+		c = p.Steps[0]
+	}
+
+	// check if there are stages in the pipeline
+	if len(p.Stages) > 0 {
+		// update the container for the init process
+		c = p.Stages[0].Steps[0]
+	}
+
+	return c, nil
+}
+
 // LoadLogs attempts to capture the library step logs
 // representing the container from the map.
 func LoadLogs(c *pipeline.Container, m *sync.Map) (*library.Log, error) {

--- a/internal/step/load_test.go
+++ b/internal/step/load_test.go
@@ -86,6 +86,101 @@ func TestStep_Load(t *testing.T) {
 	}
 }
 
+func TestStep_LoadInit(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		failure  bool
+		pipeline *pipeline.Build
+		want     *pipeline.Container
+	}{
+		{
+			failure: false,
+			pipeline: &pipeline.Build{
+				Version: "1",
+				ID:      "github_octocat_1",
+				Stages: pipeline.StageSlice{
+					{
+						Name: "init",
+						Steps: pipeline.ContainerSlice{
+							{
+								ID:          "github_octocat_1_init_init",
+								Directory:   "/vela/src/github.com/github/octocat",
+								Environment: map[string]string{"FOO": "bar"},
+								Image:       "#init",
+								Name:        "init",
+								Number:      1,
+								Pull:        "always",
+							},
+						},
+					},
+				},
+			},
+			want: &pipeline.Container{
+				ID:          "github_octocat_1_init_init",
+				Directory:   "/vela/src/github.com/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "always",
+			},
+		},
+		{
+			failure: false,
+			pipeline: &pipeline.Build{
+				Version: "1",
+				ID:      "github_octocat_1",
+				Steps: pipeline.ContainerSlice{
+					{
+						ID:          "step_github_octocat_1_init",
+						Directory:   "/vela/src/github.com/github/octocat",
+						Environment: map[string]string{"FOO": "bar"},
+						Image:       "#init",
+						Name:        "init",
+						Number:      1,
+						Pull:        "always",
+					},
+				},
+			},
+			want: &pipeline.Container{
+				ID:          "step_github_octocat_1_init",
+				Directory:   "/vela/src/github.com/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "always",
+			},
+		},
+		{
+			failure:  true,
+			pipeline: nil,
+			want:     nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := LoadInit(test.pipeline)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("LoadInit should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("LoadInit returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("LoadInit is %v, want %v", got, test.want)
+		}
+	}
+}
+
 func TestStep_LoadLogs(t *testing.T) {
 	// setup types
 	c := &pipeline.Container{


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds a new `step.LoadInit()` function to the `go-vela/pkg-executor/internal/step` package.

The intention of this function is to load the `init` process into the executor client from the pipeline.

This benefits us by reducing the non-test LOC in the executor codebase:

https://github.com/go-vela/pkg-executor/blob/1024fe8e5af1b7bdabbb73f0a2326bd37abfde85/internal/step/load.go#L38-L62