### PR TITLE
chore: add local executor to readme

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,7 +9,8 @@ Vela package designed for supporting the ability to run a [go-vela/worker](https
 
 The following executors are supported:
 
-* [Linux](https://www.linux.org/)
+* [Linux](https://www.linux.org/) - used to execute pipelines on a Linux distribution
+* Local - used to execute pipelines with the Vela CLI
 
 ## Documentation
 


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

Adding the `local` executor to the list of supported executors