### PR TITLE
fix(internal): ignore build errors in canceled state

### DIFF
--- a/executor/linux/api.go
+++ b/executor/linux/api.go
@@ -52,7 +52,7 @@ func (c *client) CancelBuild() (*library.Build, error) {
 		return nil, err
 	}
 
-	// set the build status to killed
+	// set the build status to canceled
 	b.SetStatus(constants.StatusCanceled)
 
 	p, err := os.FindProcess(os.Getpid())

--- a/executor/local/api.go
+++ b/executor/local/api.go
@@ -52,7 +52,7 @@ func (c *client) CancelBuild() (*library.Build, error) {
 		return nil, err
 	}
 
-	// set the build status to cancelled
+	// set the build status to canceled
 	b.SetStatus(constants.StatusCanceled)
 
 	p, err := os.FindProcess(os.Getpid())

--- a/executor/local/api.go
+++ b/executor/local/api.go
@@ -52,7 +52,7 @@ func (c *client) CancelBuild() (*library.Build, error) {
 		return nil, err
 	}
 
-	// set the build status to killed
+	// set the build status to cancelled
 	b.SetStatus(constants.StatusCanceled)
 
 	p, err := os.FindProcess(os.Getpid())

--- a/internal/build/snapshot.go
+++ b/internal/build/snapshot.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"strings"
 	"time"
 
 	"github.com/go-vela/sdk-go/vela"
@@ -16,12 +17,15 @@ import (
 // Snapshot creates a moment in time record of the build
 // and attempts to upload it to the server.
 func Snapshot(b *library.Build, c *vela.Client, e error, l *logrus.Entry, r *library.Repo) {
-	// check if the error provided is empty
-	if e != nil {
-		// populate build fields with error based values
-		b.SetError(e.Error())
-		b.SetStatus(constants.StatusError)
-		b.SetFinished(time.Now().UTC().Unix())
+	// check if the build is not in a canceled status
+	if !strings.EqualFold(b.GetStatus(), constants.StatusCanceled) {
+		// check if the error provided is empty
+		if e != nil {
+			// populate build fields with error based values
+			b.SetError(e.Error())
+			b.SetStatus(constants.StatusError)
+			b.SetFinished(time.Now().UTC().Unix())
+		}
 	}
 
 	// check if the logger provided is empty

--- a/internal/build/upload.go
+++ b/internal/build/upload.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"strings"
 	"time"
 
 	"github.com/go-vela/sdk-go/vela"
@@ -42,11 +43,14 @@ func Upload(b *library.Build, c *vela.Client, e error, l *logrus.Entry, r *libra
 		b.SetStatus(constants.StatusSuccess)
 	}
 
-	// check if the error provided is empty
-	if e != nil {
-		// update the build  with error based values
-		b.SetError(e.Error())
-		b.SetStatus(constants.StatusError)
+	// check if the build is not in a canceled status
+	if !strings.EqualFold(b.GetStatus(), constants.StatusCanceled) {
+		// check if the error provided is empty
+		if e != nil {
+			// update the build  with error based values
+			b.SetError(e.Error())
+			b.SetStatus(constants.StatusError)
+		}
 	}
 
 	// update the build with the finished timestamp

--- a/internal/build/upload.go
+++ b/internal/build/upload.go
@@ -47,7 +47,7 @@ func Upload(b *library.Build, c *vela.Client, e error, l *logrus.Entry, r *libra
 	if !strings.EqualFold(b.GetStatus(), constants.StatusCanceled) {
 		// check if the error provided is empty
 		if e != nil {
-			// update the build  with error based values
+			// update the build with error based values
 			b.SetError(e.Error())
 			b.SetStatus(constants.StatusError)
 		}


### PR DESCRIPTION
Fixes https://github.com/go-vela/community/issues/200

A bug was introduced in https://github.com/go-vela/pkg-executor/pull/107 that prevented builds from being in a `canceled` status.

Originally this was accomplished with https://github.com/go-vela/pkg-executor/pull/51 and https://github.com/go-vela/pkg-executor/pull/54

This creates confusion for end users who are attempting to cancel a build and reviewing their build history.

We now will check to see if the build is in a `canceled` status before attempting to populate any error messages.