### PR TITLE
fix(cancel): remove SIGTERM in favor of executor.DestroyBuild

### DIFF
--- a/executor/linux/api.go
+++ b/executor/linux/api.go
@@ -5,9 +5,8 @@
 package linux
 
 import (
+	"context"
 	"fmt"
-	"os"
-	"syscall"
 	"time"
 
 	"github.com/go-vela/pkg-executor/internal/service"
@@ -191,14 +190,9 @@ func (c *client) CancelBuild() (*library.Build, error) {
 		}
 	}
 
-	p, err := os.FindProcess(os.Getpid())
+	err = c.DestroyBuild(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("unable to find PID: %v", err)
-	}
-
-	err = p.Signal(syscall.SIGTERM)
-	if err != nil {
-		return nil, fmt.Errorf("unable to cancel PID: %v", err)
+		return nil, err
 	}
 
 	return b, nil

--- a/executor/linux/api.go
+++ b/executor/linux/api.go
@@ -192,7 +192,7 @@ func (c *client) CancelBuild() (*library.Build, error) {
 
 	err = c.DestroyBuild(context.Background())
 	if err != nil {
-		return nil, err
+		c.logger.Errorf("unable to destroy build: %v", err)
 	}
 
 	return b, nil

--- a/executor/local/api.go
+++ b/executor/local/api.go
@@ -7,6 +7,7 @@ package local
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/go-vela/pkg-executor/internal/service"
@@ -192,7 +193,7 @@ func (c *client) CancelBuild() (*library.Build, error) {
 
 	err = c.DestroyBuild(context.Background())
 	if err != nil {
-		return nil, err
+		fmt.Fprintln(os.Stdout, "unable to destroy build:", err)
 	}
 
 	return b, nil

--- a/executor/local/api.go
+++ b/executor/local/api.go
@@ -5,9 +5,8 @@
 package local
 
 import (
+	"context"
 	"fmt"
-	"os"
-	"syscall"
 	"time"
 
 	"github.com/go-vela/pkg-executor/internal/service"
@@ -191,14 +190,9 @@ func (c *client) CancelBuild() (*library.Build, error) {
 		}
 	}
 
-	p, err := os.FindProcess(os.Getpid())
+	err = c.DestroyBuild(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("unable to find PID: %v", err)
-	}
-
-	err = p.Signal(syscall.SIGTERM)
-	if err != nil {
-		return nil, fmt.Errorf("unable to cancel PID: %v", err)
+		return nil, err
 	}
 
 	return b, nil


### PR DESCRIPTION
Fixes https://github.com/go-vela/community/issues/201

Sending a SIGTERM to cancel the executor actually terminates the entire worker. In the future Go may support separate PIDs per thread https://github.com/golang/go/issues/19326