### PR TITLE
chore: upgrade go-vela/pkg-runtime on latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.7.1
 	github.com/go-vela/compiler v0.7.4
 	github.com/go-vela/mock v0.7.5-0.20210416160452-fa8721fcc6a1
-	github.com/go-vela/pkg-runtime v0.7.5-0.20210420185916-57eb15a12186
+	github.com/go-vela/pkg-runtime v0.7.5-0.20210428154035-f007d6e59a10
 	github.com/go-vela/sdk-go v0.7.4
 	github.com/go-vela/types v0.7.4
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/go-vela/compiler v0.7.4/go.mod h1:1l4DWOSHJMHVcmgq6P6PEDTQicI6KMtSn7G
 github.com/go-vela/mock v0.7.4/go.mod h1:MZBxR/A9ChWsHI/+b3NQPYF85VJqh6iYU47Wpoujjrk=
 github.com/go-vela/mock v0.7.5-0.20210416160452-fa8721fcc6a1 h1:99+SdZ72L5vTDdB4MJShE0oa5W5rUeYens/W0vhOosM=
 github.com/go-vela/mock v0.7.5-0.20210416160452-fa8721fcc6a1/go.mod h1:mjLSUHXoCVEjlfAhMhqjQuwOr7ZLNGuOxOXvjK+79jE=
-github.com/go-vela/pkg-runtime v0.7.5-0.20210420185916-57eb15a12186 h1:sCjs5Rivkuy/r2rgvjIqtj4VNr7x03DC+RFWPGbcTA0=
-github.com/go-vela/pkg-runtime v0.7.5-0.20210420185916-57eb15a12186/go.mod h1:gfF1R51abdO4noNrlfFPgrEkct+bTpftJRtw/M1hEzs=
+github.com/go-vela/pkg-runtime v0.7.5-0.20210428154035-f007d6e59a10 h1:MijNDyaFrM5iygRc0wcdJt2IL6Krth2/GTT8ZBbZopg=
+github.com/go-vela/pkg-runtime v0.7.5-0.20210428154035-f007d6e59a10/go.mod h1:gfF1R51abdO4noNrlfFPgrEkct+bTpftJRtw/M1hEzs=
 github.com/go-vela/sdk-go v0.7.4 h1:OXUR8LZzO8kBmNY3yRuFojcmjWaMoK1s2q5iIpu5vhg=
 github.com/go-vela/sdk-go v0.7.4/go.mod h1:I1K3LpWOnfsJUhHXJf7DpwR9zVz4h65hRXzQ5IOxPuo=
 github.com/go-vela/server v0.7.5-0.20210323124812-0da2c57a87ff h1:1LT69ic6xXBKSi+FngkSCJTqqv3xCWTYzdlLKg9xRzk=


### PR DESCRIPTION
This pulls in the latest changes for the [go-vela/pkg-runtime](https://github.com/go-vela/pkg-runtime) codebase.

The primary focus is to address the bug resolved with https://github.com/go-vela/pkg-runtime/pull/114