### PR TITLE
chore: upgrade go-vela/pkg-runtime on v0.7.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-vela/compiler v0.7.4
 	github.com/go-vela/mock v0.7.4
-	github.com/go-vela/pkg-runtime v0.7.4
+	github.com/go-vela/pkg-runtime v0.7.5
 	github.com/go-vela/sdk-go v0.7.4
 	github.com/go-vela/types v0.7.4
 	github.com/google/go-cmp v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/go-vela/compiler v0.7.4 h1:dJG5Qmq3eQrT+5TzrOhdWKCG9RjIXI0uKakGDAtwOc
 github.com/go-vela/compiler v0.7.4/go.mod h1:1l4DWOSHJMHVcmgq6P6PEDTQicI6KMtSn7GI8LmoJ+M=
 github.com/go-vela/mock v0.7.4 h1:YthX/HXq9796wUAd+LV++x1tHnUJoWQnKZw7Rupw54w=
 github.com/go-vela/mock v0.7.4/go.mod h1:MZBxR/A9ChWsHI/+b3NQPYF85VJqh6iYU47Wpoujjrk=
-github.com/go-vela/pkg-runtime v0.7.4 h1:uz9Zqub/YW9Tf/d2jnUc9fCv2fEGyjHMukzZ7yrRet4=
-github.com/go-vela/pkg-runtime v0.7.4/go.mod h1:CCY2iidKjW7Pte4quOG6Zn9Flx7OyV4uQEP0TM2Jj3I=
+github.com/go-vela/pkg-runtime v0.7.5 h1:Fickp6sVhLXLaselaDMBTGKrmXJ8Fjb2IpL+iESds2M=
+github.com/go-vela/pkg-runtime v0.7.5/go.mod h1:CCY2iidKjW7Pte4quOG6Zn9Flx7OyV4uQEP0TM2Jj3I=
 github.com/go-vela/sdk-go v0.7.4 h1:OXUR8LZzO8kBmNY3yRuFojcmjWaMoK1s2q5iIpu5vhg=
 github.com/go-vela/sdk-go v0.7.4/go.mod h1:I1K3LpWOnfsJUhHXJf7DpwR9zVz4h65hRXzQ5IOxPuo=
 github.com/go-vela/types v0.7.4 h1:iVz1kDS/uvkOoridyyt0bTZ5tG2j3QYx25rbyFdu35M=


### PR DESCRIPTION
Related to https://github.com/go-vela/pkg-runtime/pull/115

This is a backport of https://github.com/go-vela/pkg-runtime/pull/114 for the `v0.7.x` release.

This pulls in the `v0.7.5` tag for the [go-vela/pkg-runtime](https://github.com/go-vela/pkg-runtime) codebase.