### PR TITLE
fix: escape \\n in secrets

### DIFF
--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -347,9 +347,21 @@ func injectSecrets(ctn *pipeline.Container, m map[string]*library.Secret) error 
 		logrus.Tracef("matching secret %s to container %s", _secret.Source, ctn.Name)
 		// ensure the secret matches with the container
 		if s.Match(ctn) {
-			ctn.Environment[strings.ToUpper(_secret.Target)] = strings.Replace(s.GetValue(), "\\n", "\\\n", -1)
+			ctn.Environment[strings.ToUpper(_secret.Target)] = s.GetValue()
 		}
 	}
 
 	return nil
+}
+
+// escapeNewlineSecrets is a helper function to double-escape escaped newlines.
+// double-escaped newlines are resolved to newlines during env substitution
+func escapeNewlineSecrets(m map[string]*library.Secret) {
+	for i, secret := range m {
+		// only double-escape secrets that have been manually escaped
+		if !strings.Contains(secret.GetValue(), "\\\\n") {
+			s := strings.Replace(secret.GetValue(), "\\n", "\\\n", -1)
+			m[i].Value = &s
+		}
+	}
 }

--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -347,7 +347,7 @@ func injectSecrets(ctn *pipeline.Container, m map[string]*library.Secret) error 
 		logrus.Tracef("matching secret %s to container %s", _secret.Source, ctn.Name)
 		// ensure the secret matches with the container
 		if s.Match(ctn) {
-			ctn.Environment[strings.ToUpper(_secret.Target)] = s.GetValue()
+			ctn.Environment[strings.ToUpper(_secret.Target)] = strings.Replace(s.GetValue(), "\\n", "\\\n", -1)
 		}
 	}
 

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -766,3 +766,42 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 		}
 	}
 }
+
+func TestLinux_Secret_escapeNewlineSecrets(t *testing.T) {
+	// name and value of secret
+	n := "foo"
+	v := "bar\\nbaz"
+	vEscaped := "bar\\\nbaz"
+
+	// desired secret value
+	w := "bar\\\nbaz"
+
+	// setup types
+	tests := []struct {
+		secretMap map[string]*library.Secret
+		want      map[string]*library.Secret
+	}{
+
+		{
+			secretMap: map[string]*library.Secret{"FOO": {Name: &n, Value: &v}},
+			want:      map[string]*library.Secret{"FOO": {Name: &n, Value: &w}},
+		},
+		{
+			secretMap: map[string]*library.Secret{"FOO": {Name: &n, Value: &vEscaped}},
+			want:      map[string]*library.Secret{"FOO": {Name: &n, Value: &w}},
+		},
+	}
+
+	// run test
+	for _, test := range tests {
+		escapeNewlineSecrets(test.secretMap)
+		got := test.secretMap
+
+		// Preferred use of reflect.DeepEqual(x, y interface) is giving false positives.
+		// Switching to a Google library for increased clarity.
+		// https://github.com/google/go-cmp
+		if diff := cmp.Diff(test.want, got); diff != "" {
+			t.Errorf("escapeNewlineSecrets mismatch (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -45,6 +45,9 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 		return err
 	}
 
+	logger.Debug("escaping newlines in secrets")
+	escapeNewlineSecrets(c.Secrets)
+
 	logger.Debug("injecting secrets")
 	// inject secrets for container
 	err = injectSecrets(ctn, c.Secrets)


### PR DESCRIPTION
Fixes: https://github.com/go-vela/community/issues/75

This PR replaces all instances of `\\n` with `\\\n` within a secret and ensures that newlines within secrets are preserved when they are used within a pipeline.

This should _skip_ escaping newlines for secrets where users have manually escaped newlines
https://github.com/go-vela/pkg-executor/blob/8382d080d029e7acce0d2c7a9e6865b8137b1466/executor/linux/secret.go#L362

#### Explanation:

When secrets are injected into a pipeline, newlines are escaped (`\n` -> `\\n`), but when the types method [container.Substitute](https://github.com/go-vela/types/blob/62027576a4adda164c848c205d9ba2f08bae1178/pipeline/container.go#L289) is called from executor, [envsubst.Eval(string(body), subFunc)](https://github.com/go-vela/types/blob/62027576a4adda164c848c205d9ba2f08bae1178/pipeline/container.go#L318) it removes the escape, replacing `\\n` with `\n` and breaking how the secret is intended to be used.

