### PR TITLE
fix: use sync.Map for concurrent access

### DIFF
--- a/executor/engine.go
+++ b/executor/engine.go
@@ -6,6 +6,7 @@ package executor
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
@@ -81,10 +82,10 @@ type Engine interface {
 	CreateStage(context.Context, *pipeline.Stage) error
 	// PlanStage defines a function that
 	// prepares the stage for execution.
-	PlanStage(context.Context, *pipeline.Stage, map[string]chan error) error
+	PlanStage(context.Context, *pipeline.Stage, *sync.Map) error
 	// ExecStage defines a function that
 	// runs a stage.
-	ExecStage(context.Context, *pipeline.Stage, map[string]chan error) error
+	ExecStage(context.Context, *pipeline.Stage, *sync.Map) error
 	// DestroyStage defines a function that
 	// cleans up the stage after execution.
 	DestroyStage(context.Context, *pipeline.Stage) error

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -417,7 +418,8 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	// https://pkg.go.dev/golang.org/x/sync/errgroup?tab=doc#WithContext
 	stages, stageCtx := errgroup.WithContext(ctx)
 	// create a map to track the progress of each stage
-	stageMap := make(map[string]chan error)
+	// stageMap := make(map[string]chan error)
+	stageMap := new(sync.Map)
 
 	// iterate through each stage in the pipeline
 	for _, _stage := range c.pipeline.Stages {
@@ -430,7 +432,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		stage := _stage
 
 		// create a new channel for each stage in the map
-		stageMap[stage.Name] = make(chan error)
+		stageMap.Store(stage.Name, make(chan error))
 
 		// spawn errgroup routine for the stage
 		//

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -417,8 +417,8 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	//
 	// https://pkg.go.dev/golang.org/x/sync/errgroup?tab=doc#WithContext
 	stages, stageCtx := errgroup.WithContext(ctx)
+
 	// create a map to track the progress of each stage
-	// stageMap := make(map[string]chan error)
 	stageMap := new(sync.Map)
 
 	// iterate through each stage in the pipeline

--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -354,8 +354,8 @@ func injectSecrets(ctn *pipeline.Container, m map[string]*library.Secret) error 
 	return nil
 }
 
-// escapeNewlineSecrets is a helper function to double-escape escaped newlines.
-// double-escaped newlines are resolved to newlines during env substitution
+// escapeNewlineSecrets is a helper function to double-escape escaped newlines,
+// double-escaped newlines are resolved to newlines during env substitution.
 func escapeNewlineSecrets(m map[string]*library.Secret) {
 	for i, secret := range m {
 		// only double-escape secrets that have been manually escaped

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -103,7 +103,7 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) 
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithField
 	logger := c.logger.WithField("stage", s.Name)
 
-	// close the error channel after executing the stage
+	// close the stage channel at the end
 	defer func() {
 		// retrieve the error channel for the current stage
 		errChan, ok := m.Load(s.Name)

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -108,7 +108,7 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) 
 		// retrieve the error channel for the current stage
 		errChan, ok := m.Load(s.Name)
 		if !ok {
-			logger.Debug("unable to access error channel")
+			logger.Debugf("error channel for stage %s not found", s.Name)
 
 			return
 		}

--- a/executor/linux/stage_test.go
+++ b/executor/linux/stage_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -161,19 +162,25 @@ func TestLinux_PlanStage(t *testing.T) {
 		t.Errorf("unable to create runtime engine: %v", err)
 	}
 
-	testMap := map[string]chan error{"foo": make(chan error, 1)}
-	testMap["foo"] <- nil
-	close(testMap["foo"])
+	testMap := new(sync.Map)
+	testMap.Store("foo", make(chan error, 1))
 
-	errMap := map[string]chan error{"foo": make(chan error, 1)}
-	errMap["foo"] <- errors.New("bar")
-	close(errMap["foo"])
+	tm, _ := testMap.Load("foo")
+	tm.(chan error) <- nil
+	close(tm.(chan error))
+
+	errMap := new(sync.Map)
+	errMap.Store("foo", make(chan error, 1))
+
+	em, _ := errMap.Load("foo")
+	em.(chan error) <- errors.New("bar")
+	close(em.(chan error))
 
 	// setup tests
 	tests := []struct {
 		failure  bool
 		stage    *pipeline.Stage
-		stageMap map[string]chan error
+		stageMap *sync.Map
 	}{
 		{ // basic stage
 			failure: false,
@@ -191,7 +198,7 @@ func TestLinux_PlanStage(t *testing.T) {
 					},
 				},
 			},
-			stageMap: make(map[string]chan error),
+			stageMap: new(sync.Map),
 		},
 		{ // basic stage with nil stage map
 			failure: false,
@@ -343,8 +350,8 @@ func TestLinux_ExecStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		stageMap := make(map[string]chan error)
-		stageMap["echo"] = make(chan error)
+		stageMap := new(sync.Map)
+		stageMap.Store("echo", make(chan error, 1))
 
 		_engine, err := New(
 			WithBuild(_build),

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -287,7 +288,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 	// https://pkg.go.dev/golang.org/x/sync/errgroup?tab=doc#WithContext
 	stages, stageCtx := errgroup.WithContext(ctx)
 	// create a map to track the progress of each stage
-	stageMap := make(map[string]chan error)
+	stageMap := new(sync.Map)
 
 	// iterate through each stage in the pipeline
 	for _, _stage := range c.pipeline.Stages {
@@ -300,7 +301,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		stage := _stage
 
 		// create a new channel for each stage in the map
-		stageMap[stage.Name] = make(chan error)
+		stageMap.Store(stage.Name, make(chan error))
 
 		// spawn errgroup routine for the stage
 		//

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -77,7 +77,6 @@ func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) 
 
 // ExecStage runs a stage.
 func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) error {
-
 	// close the stage channel at the end
 	defer func() {
 		errChan, ok := m.Load(s.Name)

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/go-vela/pkg-executor/internal/step"
 	"github.com/go-vela/types/pipeline"
@@ -49,11 +50,11 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 }
 
 // PlanStage prepares the stage for execution.
-func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
+func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) error {
 	// ensure dependent stages have completed
 	for _, needs := range s.Needs {
 		// check if a dependency stage has completed
-		stageErr, ok := m[needs]
+		stageErr, ok := m.Load(needs)
 		if !ok { // stage not found so we continue
 			continue
 		}
@@ -62,7 +63,7 @@ func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m map[string]
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("errgroup context is done")
-		case err := <-stageErr:
+		case err := <-stageErr.(chan error):
 			if err != nil {
 				return err
 			}
@@ -75,9 +76,17 @@ func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m map[string]
 }
 
 // ExecStage runs a stage.
-func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
+func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) error {
+
 	// close the stage channel at the end
-	defer close(m[s.Name])
+	defer func() {
+		errChan, ok := m.Load(s.Name)
+		if !ok {
+			return
+		}
+
+		close(errChan.(chan error))
+	}()
 
 	// execute the steps for the stage
 	for _, _step := range s.Steps {


### PR DESCRIPTION
fixes: https://github.com/go-vela/community/issues/342

i was able to reproduce the issue by constraining the resources in the supplied `docker-compose.yml` for the `worker` service on my local machine:
```yaml
worker:
  deploy:
    resources:
      limits:
        cpus: '0.50'
        memory: 10M
```

then, i crafted a pipeline (`.vela.star`) as follows:
```starlark
def create_stages(n):
  s = {}
  for i in range(1, n): 
    s["stage_" + str(i)] = {
      "steps": [
        {
          "name": "echo-step-for-stage-" + str(i),
          "image": "alpine:latest",
          "commands": [
            "echo hello from stage " + str(i),
            "sleep 5",
            "echo done"
          ]
        }
      ]
    }
    
  return s

def main(ctx):
  return {
      'version': '1',
      'stages': create_stages(100)
  }
```

the pipeline creates 100 stages with one identical step. this resulted in the unsafe concurrent map access in about 80% of builds which then result in hanging builds, that means.. the worker service crashes and restarts. in the other cases the service exited due to OOM error (exit code 137) - somewhat expected.

with the changes in this PR (switching to `sync.Map`), the concurrent map access error disappeared completely. i ran 10+ test runs with and without the changes.
