### PR TITLE
chore(docs): add migration disclaimer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing
 
+> DISCLAIMER:
+>
+> This contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
+>
+> This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
+
 We'd love to accept your contributions to this project! There are just a few guidelines you need to follow.
 
 ## Bugs

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 > DISCLAIMER:
 >
-> This contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
+> The contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
 >
 > This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,7 @@
 
 > DISCLAIMER:
 >
-> This contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
+> The contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
 >
 > This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,11 @@
 # pkg-executor
 
+> DISCLAIMER:
+>
+> This contents of this repository have been migrated into [go-vela/worker](https://github.com/go-vela/worker).
+>
+> This was done as a part of [go-vela/community#395](https://github.com/go-vela/community/issues/395) to deliver [on a proposal](https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md).
+
 [![license](https://img.shields.io/crates/l/gl.svg)](../LICENSE)
 [![GoDoc](https://godoc.org/github.com/go-vela/pkg-executor?status.svg)](https://godoc.org/github.com/go-vela/pkg-executor)
 [![Go Report Card](https://goreportcard.com/badge/go-vela/pkg-executor)](https://goreportcard.com/report/go-vela/pkg-executor)


### PR DESCRIPTION
Dependent on https://github.com/go-vela/worker/pull/219 and https://github.com/go-vela/worker/pull/220

Related to https://github.com/go-vela/community/blob/master/proposals/2021/08-25_repo-structure.md

Part of the effort for https://github.com/go-vela/community/issues/395

This adds a disclaimer about the content of this repository being migrated to [go-vela/worker](https://github.com/go-vela/worker).

After this change is merged, the plan will to be archive this repository.